### PR TITLE
Add GitHub release workflow for Gemini CLI extension

### DIFF
--- a/.github/workflows/release-gemini.yml
+++ b/.github/workflows/release-gemini.yml
@@ -1,0 +1,68 @@
+name: Release Gemini extension
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Read version from package.json
+        id: version
+        run: |
+          VERSION=$(node -p "require('./package.json').version")
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "tag=v$VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Check if release already exists
+        id: check
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          if gh release view "${{ steps.version.outputs.tag }}" > /dev/null 2>&1; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+            echo "Release ${{ steps.version.outputs.tag }} already exists — skipping."
+          else
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Build Gemini extension archive
+        if: steps.check.outputs.exists == 'false'
+        run: |
+          # Archive revenuecat/ contents, excluding dot-directories and dot-files,
+          # with gemini-extension.json at the archive root.
+          tar -czf /tmp/revenuecat.tar.gz \
+            -C revenuecat \
+            --exclude='.*' \
+            .
+
+      - name: Create GitHub release
+        if: steps.check.outputs.exists == 'false'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release create "${{ steps.version.outputs.tag }}" \
+            /tmp/revenuecat.tar.gz#revenuecat.tar.gz \
+            --title "RevenueCat AI Toolkit ${{ steps.version.outputs.tag }}" \
+            --notes "## Gemini CLI
+
+Install this extension with:
+
+\`\`\`
+gemini extensions install https://github.com/${{ github.repository }} --tag ${{ steps.version.outputs.tag }}
+\`\`\`
+
+Or install the latest release:
+
+\`\`\`
+gemini extensions install https://github.com/${{ github.repository }}
+\`\`\`
+
+See the [README](https://github.com/${{ github.repository }}#readme) for full setup instructions." \
+            --latest

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Then, in the Codex app, click on "Plugins". From the "Built by OpenAI" dropdown,
 ### Gemini CLI
 
 ```bash
-gemini extensions install https://github.com/RevenueCat/ai-toolkit --path revenuecat
+gemini extensions install https://github.com/RevenueCat/ai-toolkit
 ```
 
 

--- a/package.json
+++ b/package.json
@@ -4,7 +4,6 @@
   "description": "RevenueCat plugin marketplace for AI coding assistants",
   "type": "module",
   "scripts": {
-    "build:gemini": "node scripts/build-gemini.mjs"
   },
   "license": "MIT",
   "author": {

--- a/revenuecat/gemini-extension.json
+++ b/revenuecat/gemini-extension.json
@@ -2,7 +2,6 @@
   "name": "revenuecat",
   "version": "2.0.0",
   "description": "Configure RevenueCat projects, products, entitlements, and offerings from Gemini CLI.",
-  "contextFileName": "GEMINI.md",
   "mcpServers": {
     "revenuecat": {
       "type": "http",


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/release-gemini.yml`: on every merge to `main`, packages `revenuecat/` (excluding dot-dirs) into a `revenuecat.tar.gz` archive and creates a versioned GitHub release so Gemini CLI can discover and install the extension via the Latest release
- Skips release creation if the tag already exists, so merges without a version bump are no-ops
- Fixes `gemini-extension.json`: removes `contextFileName: GEMINI.md` (file doesn't exist — would cause a silent install failure)
- Updates the README Gemini install command (removes the bogus `--path` flag)

## How it works

1. Reads version from `package.json` → tag `v{version}`
2. Checks if that GitHub release already exists; skips if so
3. Archives `revenuecat/` with `--exclude='.*'` to strip platform-specific manifests (`.claude-plugin/`, `.cursor-plugin/`, `.codex-plugin/`, `.mcp.json`)
4. Creates a GitHub release with `revenuecat.tar.gz` as the asset — `gemini-extension.json` lands at archive root as required

## Test plan

- [ ] Merge to `main` with a new version → verify release is created with `revenuecat.tar.gz` asset and `gemini-extension.json` at archive root
- [ ] Merge to `main` without bumping version → verify workflow skips release creation
- [ ] `gemini extensions install https://github.com/RevenueCat/ai-toolkit` installs successfully from the release

🤖 Generated with [Claude Code](https://claude.com/claude-code)