### PR TITLE
Improve revenuecat-charts skill

### DIFF
--- a/revenuecat/skills/revenuecat-charts/SKILL.md
+++ b/revenuecat/skills/revenuecat-charts/SKILL.md
@@ -25,7 +25,6 @@ giving advice, always use benchmark data to make sure you aren't incorrectly dia
 
 General guidelines:
 
-- If you are asked for metrics that there is no RevenueCat source for, confirm the definition of the metric with the user. You may make a suggestion, but do not assume a definition.
 - When using the data tools, date ranges are inclusive (start_date and end_date are included in the range). When asked for data for the "last N days", take that into account (use today as end date, start date is (N-1) days before today).
 - Provide links to RevenueCat charts (see the Dashboard URL Format section below) where it is useful. Provide specific links including filters, segments, date ranges, etc — eg. if you are asked for proceeds in the last 3 months, link to the revenue chart with custom date range of the last 3 months and the `revenue_type` selector set to `proceeds`, don't link to the plain revenue chart
 

--- a/revenuecat/skills/revenuecat-charts/SKILL.md
+++ b/revenuecat/skills/revenuecat-charts/SKILL.md
@@ -15,37 +15,81 @@ In general, to avoid clogging the context, start with defined timeframes and lar
 
 Subscription apps are driven by four forces:
 
-Acquisition - how many new customers are arriving to the app
-Conversion - how many of those customers are converting into trials or paid paid plans
-Retention - how long do those customers retain
-Reactivation - how can you bring back old users
+- Acquisition - how many new customers are arriving to the app
+- Conversion - how many of those customers are converting into trials or paid plans
+- Retention - how long do those customers retain
+- Reactivation - how can you bring back old users
 
-The net movement of an apps revenue will be the result of the combination of these forces. When giving advice, always use benchmark data to make sure you aren't incorrectly diagnosing an issue.
+The net movement of an apps revenue will be the result of the combination of these forces. When
+giving advice, always use benchmark data to make sure you aren't incorrectly diagnosing an issue.
+
+General guidelines:
+
+- If you are asked for metrics that there is no RevenueCat source for, confirm the definition of the metric with the user. You may make a suggestion, but do not assume a definition.
+- When using the data tools, date ranges are inclusive (start_date and end_date are included in the range). When asked for data for the "last N days", take that into account (use today as end date, start date is (N-1) days before today).
+- Provide links to RevenueCat charts (see the Dashboard URL Format section below) where it is useful. Provide specific links including filters, segments, date ranges, etc — eg. if you are asked for proceeds in the last 3 months, link to the revenue chart with custom date range of the last 3 months and the `revenue_type` selector set to `proceeds`, don't link to the plain revenue chart
+
+## Revenue
+
+- When asked for general revenue numbers without additional specification, default to gross revenue (ie. revenue including taxes and store commissions) and call it out.
 
 ## Acquisition
 
 - Use the New Customers chart to understand how much top of funnel the app is driving.
-- Segmenting New Customers by Country, or Apple Search Ads dimensions can be helpful in informing acquisition
+- Segmenting New Customers by Country, or Apple Ads dimensions can be helpful in informing
+  acquisition.
+  - RevenueCat's Apple Ads integration sets attribution dimension information like campaign, ad
+    group, keyword
+  - Developers can also manually set these attribution dimensions on a per-customer level using
+    reserved customer attributes
+- Do not treat a zero result from an explicit attribution filter as proof that the broader channel
+  has zero users or zero activity. For example, `attribution_source = Organic` only means users
+  explicitly tagged with that value; it does not include untagged users or every organic/non-paid
+  user.
+- If attribution data is sparse or missing, say that clearly. Use "unattributed" or "not explicitly
+  tagged" rather than assuming those users came from a specific channel.
 
 ## Conversion
 
-The definition of conversion may vary depending on what model the app is using. They may be converting to a trial, that then converts into a subscription. Or they may be sending users directly to a subscription.
+The definition of conversion may vary depending on what model the app is using. They may be
+converting to a trial, that then converts into a subscription. Or they may be sending users directly
+to a subscription.
 
 - Use the Initial Conversion chart to see how many trial or subscriptions are started.
-- You can then further determine if they are using free trials by comparing that to the New Trials chart
-- The Trial Conversion Rate chart is a helpful chart for understanding the performance of just that trial conversion
+- You can then further determine if they are using free trials by comparing that to the New Trials
+  chart
+- The Trial Conversion Rate chart is a helpful chart for understanding the performance of just that
+  trial conversion
 
 ## Retention
 
-- The Churn chart will tell you the % of the active subscriber base that is lost each period. It can be difficult to interpret or benchmark because it is a blend of different periods.
-- When you want to understand the long term retention of different products, look at the Subscription Retention chart
+- The Churn chart will tell you the % of the active subscriber base that is lost each period. It can
+  be difficult to interpret or benchmark because it is a blend of different periods.
+- When you want to understand the long term retention of different products, look at the
+  Subscription Retention chart
 
 ## Reactivation
 
-- The only real way to understand Reactivation is looking at the MRR Movement chart and the Resubscription MRR
+- The only real way to understand Reactivation is looking at the MRR Movement chart and the
+  Resubscription MRR
+
+## Analytics comparisons
+
+- Compare like with like. When analyzing an acquisition cohort or segment, compare it against the
+  overall baseline using the same metric, chart, date range, conversion window, and cohort
+  definition before making a directional claim.
+- For open-ended questions like "how are {segment} users doing?", do not stop at segment-only
+  metrics. Pull the requested segment and an overall/unfiltered baseline for the key conversion or
+  revenue-quality metric, then judge performance relative to that baseline. Do not evaluate a
+  segment as "healthy", "underperforming" etc. without comparing it to a baseline.
+- Do not compare revenue or conversions from a filtered new-customer cohort against total app
+  revenue from all cohorts and renewals. If you cannot get a matching baseline, say so and avoid
+  directional performance claims.
 
 
-## Dashboard URL Format
+# Dashboard URL Format
+
+Generate shareable links to RevenueCat dashboard charts with filters preserved.
 
 **IMPORTANT**: Use this exact structure:
 
@@ -73,52 +117,52 @@ https://app.revenuecat.com/charts/revenue?project=proj56965ae1&chart_start=...&c
 
 ### Date Range (`range`) — REQUIRED
 
-The `range` parameter controls the date range. Format: `{preset}:{start_date}:{end_date}`
+The `range` parameter controls the date range. Format: `{preset}:{start_date}:{end_date}`, with
+start_date and end_date in YYYY-MM-DD format. Use `Custom` as the preset for arbitrary date ranges.
 
-**You must use this format** — do NOT use `start_date`, `end_date`, `chart_start`, or `chart_end` params.
+**You must use this format** — do NOT use `start_date`, `end_date`, `chart_start`, or `chart_end`
+params. Note: The `:` between parts must be URL-encoded as `%3A`. Spaces in the preset name become
+`+`.
 
-| Preset        | Encoded Value                                   |
-| ------------- | ----------------------------------------------- |
-| Last 7 days   | `range=Last+7+days%3A2026-02-06%3A2026-02-13`   |
-| Last 28 days  | `range=Last+28+days%3A2026-01-16%3A2026-02-13`  |
-| Last 90 days  | `range=Last+90+days%3A2025-11-16%3A2026-02-13`  |
-| Last 365 days | `range=Last+365+days%3A2025-02-13%3A2026-02-13` |
-| Custom        | `range=Custom%3A2025-01-01%3A2025-12-31`        |
-
-Note: The `:` between parts must be URL-encoded as `%3A`. Spaces become `+`.
+Example: `range=Custom%3A2025-01-01%3A2025-12-31`
 
 ### Resolution (`resolution`)
 
-| Value     | Meaning               |
-| --------- | --------------------- |
-| `day`     | Daily granularity     |
-| `week`    | Weekly granularity    |
-| `month`   | Monthly granularity   |
-| `quarter` | Quarterly granularity |
-| `year`    | Yearly granularity    |
+| Value | Meaning               |
+| ----- | --------------------- |
+| `0`   | Daily granularity     |
+| `1`   | Weekly granularity    |
+| `2`   | Monthly granularity   |
+| `3`   | Quarterly granularity |
+| `4`   | Yearly granularity    |
 
-### Segment (`segment_by`)
+### Segment (`segment`)
 
-Dimension to break down the data by. Common values:
+Dimension to break down the data by. Use the exact value you were using to make the `get-chart-data`
+request.
 
 - `country` — by country
 - `store` — by app store (App Store, Play Store, etc.)
-- `product` — by product identifier
+- `product_id` — by product identifier
 - `platform` — by platform (iOS, Android, etc.)
-- `offering` — by offering
+- `offering_id` — by offering
 
 ### Filters
 
-Filters are passed as individual query params with the filter name as key:
+Filters are passed as individual query `filter` params with the content
+`{dimension}%3A%3D%3A{value}`. Use the dimension names you used for the `get-chart-data` request.
 
-| Filter               | Example                              |
-| -------------------- | ------------------------------------ |
-| `country`            | `country=US`                         |
-| `store`              | `store=app_store`                    |
-| `product_identifier` | `product_identifier=premium_monthly` |
-| `platform`           | `platform=iOS`                       |
+| Dimension  | Example                                    |
+| ---------- | ------------------------------------------ |
+| `country`  | `filter=country%3A%3D%3AUS`                |
+| `store`    | `filter=store%3A%3D%3Aapp_store`           |
+| `product`  | `filter=product_id%3A%3D%3Aprodbb68905d98` |
+| `platform` | `filter=platform%3A%3D%3AiOS`              |
 
-Multiple values for the same filter: `country=US&country=DE&country=JP`
+To use multiple filters, regardless of whether they are for the same dimension or multiple
+dimensions, include multiple `filter` query parameters. Passing multiple filters for the same
+dimension will result in an OR operation, passing filters for different dimensions will result in an
+AND operation.
 
 ### Chart-Specific Selectors
 
@@ -126,13 +170,8 @@ Some charts have special selectors:
 
 **Conversion/Retention charts:**
 
-- `customer_lifetime` — e.g., `30+days`, `60+days`, `90+days`
-- `conversion_timeframe` — e.g., `7+days`, `14+days`, `30+days`
-
-**Workflow charts:**
-
-- `path` — workflow path filter
-- `workflows_customer_lifetime` — e.g., `initial`
+- `customer_lifetime` — e.g., `30_days`, `60_days`, `90_days`
+- `conversion_timeframe` — e.g., `7_days`, `14_days`, `30_days`
 
 ## Constructing a Link
 
@@ -140,8 +179,8 @@ To generate a dashboard link:
 
 1. Start with base: `https://app.revenuecat.com/projects/{project_id}/charts/{chart_name}`
 2. Add `range` param with date range
-3. Add any filters as query params
-4. Add `segment_by` if segmenting
+3. Add any filters as `filter` query params
+4. Add `segment` if segmenting
 5. Add chart-specific selectors as needed
 6. URL-encode all values (spaces → `+`, colons → `%3A`, etc.)
 
@@ -152,11 +191,9 @@ When translating from API parameters to dashboard URLs:
 | API Parameter             | Dashboard Parameter                                    |
 | ------------------------- | ------------------------------------------------------ |
 | `start_date` + `end_date` | `range=Custom%3A{start}%3A{end}` (use `Custom` preset) |
-| `segment`                 | `segment_by`                                           |
-| `filters` (JSON array)    | Individual query params                                |
+| `segment`                 | `segment`                                              |
+| `filters` (JSON array)    | Individual `filter` query params                       |
 | `selectors` (JSON object) | Individual query params                                |
-
-**Note**: Do NOT pass `resolution` as a numeric value. The resolution is typically implied by the range preset or omitted.
 
 ## Example: Building a Link
 
@@ -165,7 +202,7 @@ User wants: "Revenue chart for last 90 days, segmented by country, filtered to U
 Calculate dates: if today is 2026-02-13, then 90 days ago is 2025-11-16.
 
 ```
-https://app.revenuecat.com/projects/56965ae1/charts/revenue?range=Last+90+days%3A2025-11-16%3A2026-02-13&segment_by=country&country=US&country=DE
+https://app.revenuecat.com/projects/56965ae1/charts/revenue?range=Last+90+days%3A2025-11-16%3A2026-02-13&segment=country&filter=country%3A%3D%3AUS&filter=country%3A%3D%3ADE
 ```
 
 User wants: "Churn chart from August 2025 to now"
@@ -178,8 +215,7 @@ https://app.revenuecat.com/projects/56965ae1/charts/churn?range=Custom%3A2025-08
 
 ## Getting Project ID
 
-The project ID can be found via the API:
+The project ID can be found via the `list_projects` tool, which lists all projects with their ID.
 
-- `GET /projects` — lists all projects with their IDs
-- API returns IDs like `proj56965ae1`
+- The tool returns IDs starting with `proj`, for example `proj56965ae1`
 - **For dashboard URLs, strip the `proj` prefix** — use just `56965ae1` in the path


### PR DESCRIPTION
## Summary

Corrects issues in `revenuecat-charts` skill 

### Interpretation guidance 
- Fix the "paid paid plans" typo; make the four-forces a proper bullet list
- Add **General guidelines** (metric-definition confirmation, inclusive date ranges, specific-link guidance)
- Add a **Revenue** section (default to gross, call it out)
- Expand **Acquisition** with attribution caveats; correct "Apple Search Ads" → "Apple Ads"
- Add an **Analytics comparisons** section (compare like-with-like, always pull a baseline)

### Chart-link formats 
- **Resolution**: numeric `0`–`4` instead of `day`/`week`/`month`; removed the contradictory "do NOT pass numeric" note
- **Segment**: `segment` (not `segment_by`); values `product_id`/`offering_id`
- **Filters**: `filter=country%3A%3D%3AUS` syntax (with OR/AND semantics) instead of `country=US`
- **Selectors**: underscore format `30_days`/`7_days` instead of `30+days`
- **Project ID**: sourced via the `list_projects` tool

### Preserved (ai-toolkit-specific, not incorrect)
Full `https://app.revenuecat.com/...` URL base, the RevenueCat MCP tool intro (`get-chart-options-schema` / `get-chart-data`), and preset-name examples like `Last+90+days`.

### Note for reviewers
Removed the **"Workflow charts"** selectors (`path`, `workflows_customer_lifetime`) — Rico doesn't document them, and they shared the block whose `+days` format was being corrected, so they couldn't be verified against the source of truth. Re-add if known valid.

🤖 Generated with [Claude Code](https://claude.com/claude-code)