### PR TITLE
Teach RevenueCat skills CLI project setup workflows

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,30 @@ npx skills add RevenueCat/ai-toolkit --global
 Note that this will only install the skills from this repository, not the MCP server. Configure the MCP manually in your coding environment [following our instructions](https://www.revenuecat.com/docs/tools/mcp/setup).
 Omit `--global` only when you intentionally want the skills and lock file scoped to the current project.
 
+### Use an installed skill
+
+After installing or updating skills, start a new agent session or reload the
+agent so it discovers the latest skill metadata. Installation makes skills
+available; it does not execute a workflow.
+
+Agents can select a skill automatically when the request matches its
+description. To make project creation predictable across clients, name it:
+
+```text
+Use the create-revenuecat-project skill to create my RevenueCat account and
+configure my project, apps, products, entitlements, and offerings.
+```
+
+Natural requests such as “Set up RevenueCat for my new iOS app” should also
+select the project-creation skill. Explicit naming is recommended for testing
+and for clients that do not reliably auto-select skills.
+
+The project-creation skill checks authentication first. When account creation
+is needed, it asks for explicit authorization before accepting RevenueCat's
+Terms, keeps marketing opt-in separate, and can direct the local macOS CLI to
+generate a password and save it in Keychain. The skill then orchestrates the
+real `rc` commands for project and catalog setup directly.
+
 ## Authentication
 
 The plugin requires authentication with your RevenueCat account via OAuth.

--- a/README.md
+++ b/README.md
@@ -100,10 +100,11 @@ Plugin marketplace support is currently in beta in Visual Studio Code. Refer to 
 Use `npx skills`:
 
 ```
-npx skills add RevenueCat/ai-toolkit
+npx skills add RevenueCat/ai-toolkit --global
 ```
 
 Note that this will only install the skills from this repository, not the MCP server. Configure the MCP manually in your coding environment [following our instructions](https://www.revenuecat.com/docs/tools/mcp/setup).
+Omit `--global` only when you intentionally want the skills and lock file scoped to the current project.
 
 ## Authentication
 

--- a/revenuecat/skills/create-revenuecat-project/SKILL.md
+++ b/revenuecat/skills/create-revenuecat-project/SKILL.md
@@ -1,89 +1,131 @@
 ---
 name: create-revenuecat-project
-description: "Set up a complete RevenueCat project from scratch — creates apps, products, entitlements, offerings, and packages in the correct order. Use when the user wants to create a new RevenueCat project, configure in-app purchases, set up subscriptions or monetization, or bootstrap IAP infrastructure for iOS, Android, or Web."
+description: "Bootstrap a complete RevenueCat project with apps, store products, credentials, entitlements, offerings, packages, and SDK keys. Use when creating a RevenueCat project, configuring in-app purchases, or setting up subscriptions for iOS, Android, or Web with the RevenueCat CLI or MCP server."
 ---
 
-# RevenueCat Project Bootstrap
+# RevenueCat project bootstrap
 
-Guide through setting up a complete RevenueCat project from scratch.
+Build a usable RevenueCat project in dependency order. Prefer the RevenueCat CLI (`rc`) when it is installed and exposes the required commands; otherwise use the RevenueCat MCP tools.
 
-## Instructions
+## Discover the available surface
 
-**Important:** Use the RevenueCat MCP server for all tool calls. The MCP server may have access to multiple projects. Always use `list-projects` first to retrieve all accessible projects. If multiple projects are returned, ask the user which project to use or if they want to create a new one.
+For the CLI path, inspect the installed version instead of assuming its flags:
 
-### Phase 1: Discovery
-
-Ask targeted questions to understand the developer's needs:
-
-1. **Platforms** — "Which platforms are you building for?" (iOS, Android, Web, or multiple)
-2. **Business Model** — "What type of monetization are you planning?" (subscriptions, one-time purchases, consumables, or a mix)
-3. **Subscription Tiers** (if applicable) — "What subscription options do you want to offer?" (common: Monthly + Annual, single tier, Freemium + Premium)
-4. **App Details** — Bundle ID (iOS, e.g. `com.company.appname`), package name (Android), and display name
-
-### Phase 2: Create Resources
-
-Execute in this order — dependencies matter. 
-
-1. Verify/Create Project
-`list-projects` - list accessible projects
-If multiple: ask user which to use, or offer to create a new one
-To create a new project, use the `create-project` MCP tool
-Store project_id for all subsequent calls
-
-2. Create Apps (for each platform): 
-    - For mobile apps, ask if the user already has set up their app in App Store Connect / Google Play Console. If so, create an app using the `create-app` tool (type: app_store | play_store). If not, use the automatically generated `test_store` app and tell the user that they can set up the integration with App Store Connect / Google Play Console later.
-    - For web apps, `create-app` with type rc_billing
-
-3. Create Products (for each subscription/purchase): `create-product` tool
-
-4. Create Entitlements (for each feature/access level): `create-entitlement` tool
-
-5. Attach Products to Entitlements: `attach-products-to-entitlement` tool
-
-6. Create Default Offering: `create-offering` tool (lookup_key: "default")
-
-7. Create Packages in Offering: `create-package` tool (for subscriptions, use $rc_monthly, $rc_annual, etc.)
-
-8. Attach Products to Packages: `attach-products-to-package` tool
-
-9. Get API Keys: `list-app-public-api-keys` tool
-
-### Phase 3: Summary & Next Steps
-
-Provide a complete setup summary:
-
-```
-Project Setup Complete!
-=======================
-
-Project: {project_name} ({project_id})
-
-Apps Created:
-  iOS: {app_name} - API Key: appl_xxxxx
-  Android: {app_name} - API Key: goog_xxxxx
-
-Products:
-  - monthly_premium (subscription, P1M)
-  - annual_premium (subscription, P1Y)
-
-Entitlements:
-  - premium → monthly_premium, annual_premium
-
-Offering: default (current)
-  └── $rc_monthly → monthly_premium
-  └── $rc_annual → annual_premium
-
-Next Steps:
-1. Configure store credentials in RevenueCat dashboard
-2. Create products in App Store Connect / Play Console
-3. Add SDK to your app (see /rc:create-app)
-4. Implement paywall UI using the "default" offering
+```bash
+rc commands --json
+rc schema projects create --json
+rc schema apps create --json
+rc schema products store plan --json
 ```
 
-## Error Handling
+Use `rc schema <command> --json` before any command whose arguments are unclear. In agent or script sessions, always pass `--json --no-input`, provide every required value explicitly, and parse the JSON envelope's `data` field. Do not scrape human-readable output.
 
-If any step fails:
-1. Report the specific error clearly
-2. Suggest fixes (e.g., "Bundle ID may already be in use")
-3. Offer to retry or skip that step
-4. Continue with remaining steps if possible
+For the MCP path, inspect the available RevenueCat tools and their schemas. Always call `list-projects` before selecting or creating a project.
+
+## Gather the design
+
+Ask only for information that cannot be discovered:
+
+1. Platforms: iOS, Android, Web, or a combination
+2. RevenueCat project name and whether an existing project should be reused
+3. App display names and bundle/package identifiers
+4. Products: subscriptions, non-consumables, consumables, durations, prices, currencies, and localizations
+5. Entitlements and which products unlock them
+6. Offering/package layout
+7. Whether each mobile app already exists in its store
+
+List existing resources before creating them. Reuse a resource that already represents the requested identifier. Never create duplicates merely because an earlier command's output is unavailable.
+
+## CLI workflow
+
+### 1. Create or select the project and apps
+
+List projects first. Create only when needed:
+
+```bash
+rc projects list --json --no-input
+rc projects create --name "Example" --json --no-input
+```
+
+The created project ID is `data.project.id`. Pass `--project-id <project-id>` to later commands so the workflow does not require writing repository or global configuration. Creating with `--use` is optional convenience for a human who wants to persist the active project.
+
+List apps, then create the missing platform apps according to `rc schema apps create --json`. Capture every app ID from the response.
+
+### 2. Configure Apple access locally
+
+For an App Store app, check access before attempting setup:
+
+```bash
+rc apps apple check <app-id>
+rc apps apple setup <app-id>
+```
+
+These commands log into Apple locally and may prompt for a masked password, trusted-device 2FA code, or SMS verification. Apple sign-in credentials go directly from the local CLI to Apple; RevenueCat does not receive or store them.
+
+Never ask the user to paste an Apple password, session cookie, or 2FA code into chat, a prompt visible to the model, a command-line flag, or a file. Never run Apple authentication through a remote unattended agent. Hand the exact command to the human in a local interactive terminal and wait for its result. Run `check` first because it is read-only. Run `setup` only after the user approves creating missing In-App Purchase and App Store Connect API keys and uploading those keys to RevenueCat. One-time key downloads cannot be recovered later.
+
+Apple Small Business Program dates are outside this workflow.
+
+### 3. Plan and apply store products
+
+Use the `revenuecat-store-state` skill for store product creation, pricing, availability, and localizations. For an agent, use the durable `plan` -> `show` -> `apply` lifecycle and retain the returned plan ID. Do not substitute a second plan for the reviewed plan.
+
+After apply succeeds, list RevenueCat products again and capture their IDs. Store identifiers and RevenueCat product IDs are different values.
+
+### 4. Create the RevenueCat graph
+
+Create in dependency order, checking for an existing matching resource before each create:
+
+1. Entitlements
+2. Product-to-entitlement attachments
+3. Offering, normally with lookup key `default`
+4. Packages, using standard identifiers such as `$rc_monthly` and `$rc_annual` when appropriate
+5. Product-to-package attachments
+6. Current offering selection
+
+The CLI attachment arguments are positional:
+
+```bash
+rc entitlements attach <entitlement-id> <product-id>... --json --no-input
+rc packages attach <package-id> <product-id>... --json --no-input
+rc offerings set-current <offering-id> --yes --json --no-input
+```
+
+Use `rc schema` to discover the create commands' required flags. Pass `--project-id <project-id>` throughout unless the user intentionally configured an active project.
+
+### 5. Retrieve typed SDK keys and verify
+
+```bash
+rc apps keys <app-id> --json --no-input
+```
+
+Retrieve keys separately for every app. Verify the final state by listing apps, products, entitlements, offerings, and packages. Report stable IDs and lookup keys, not secrets.
+
+## MCP fallback
+
+When `rc` is unavailable or lacks the required command, use RevenueCat MCP tools in the same dependency order:
+
+1. `list-projects`, then `create-project` only if needed
+2. `create-app` for each missing app (`app_store`, `play_store`, or `rc_billing`)
+3. `create-product`
+4. `create-entitlement`
+5. `attach-products-to-entitlement`
+6. `create-offering`
+7. `create-package`
+8. `attach-products-to-package`
+9. `list-app-public-api-keys`
+
+MCP can configure RevenueCat resources but does not replace the local Apple credential handoff. If a store app or product is not ready, explain the remaining store-console work rather than silently substituting a test-store app unless the user explicitly requests one.
+
+## Completion report
+
+Summarize:
+
+- Project and app IDs
+- Store identifiers and RevenueCat product IDs
+- Entitlement-to-product mapping
+- Current offering, packages, and their product mapping
+- Public SDK keys by app
+- Any skipped or failed step and the exact recovery command
+
+If a command fails, inspect current state before retrying. Continue independent steps when safe, but do not claim the bootstrap is complete while a required store operation is pending or failed.

--- a/revenuecat/skills/create-revenuecat-project/SKILL.md
+++ b/revenuecat/skills/create-revenuecat-project/SKILL.md
@@ -1,11 +1,46 @@
 ---
 name: create-revenuecat-project
-description: "Bootstrap a complete RevenueCat project with apps, store products, credentials, entitlements, offerings, packages, and SDK keys. Use when creating a RevenueCat project, configuring in-app purchases, or setting up subscriptions for iOS, Android, or Web with the RevenueCat CLI or MCP server."
+description: "Create and configure a complete RevenueCat project with account signup, apps, store products, credentials, entitlements, offerings, packages, and SDK keys. Use when creating a RevenueCat account or project, configuring in-app purchases, or setting up subscriptions for iOS, Android, or Web with the RevenueCat CLI or MCP server."
 ---
 
-# RevenueCat project bootstrap
+# Create a RevenueCat project
 
 Build a usable RevenueCat project in dependency order. Prefer the RevenueCat CLI (`rc`) when it is installed and exposes the required commands; otherwise use the RevenueCat MCP tools.
+
+## Authenticate or create the account
+
+Run `rc auth status --json --no-input` before project discovery. If the user is already authenticated, continue without changing credentials.
+
+If no RevenueCat account exists and the user asks the agent to create one, gather:
+
+1. Email address
+2. Personal/display name, not a project or company name
+3. Explicit authorization to accept the RevenueCat Terms of Service and Privacy Policy
+
+Never infer legal acceptance from a general request to configure RevenueCat. Never opt into marketing email unless the user separately requests it.
+
+On the user's local Mac, create the account with a generated password saved directly to macOS Keychain:
+
+```bash
+rc auth signup \
+  --email "user@example.com" \
+  --name "User Name" \
+  --generate-password \
+  --save-password \
+  --accept-terms \
+  --json --no-input
+```
+
+Do not add `--marketing-emails` without explicit opt-in. Do not ask the user to paste a password into chat. Do not use `--password`; if the user requires a chosen password, ask them to run interactive `rc auth signup` locally or provide `RC_PASSWORD` outside the model-visible conversation.
+
+Require all of these response fields before continuing:
+
+- `data.account_created == true`
+- `data.authenticated == true`
+- `data.password_saved_to_keychain == true`
+- `data.method == "oauth"`
+
+A locked Keychain may require local user approval. If Keychain storage is false or the command fails after account creation, stop and report the exact recovery guidance; do not silently continue as though the website password is recoverable. Tell the user to complete email verification when RevenueCat sends the verification email.
 
 ## Discover the available surface
 
@@ -128,4 +163,4 @@ Summarize:
 - Public SDK keys by app
 - Any skipped or failed step and the exact recovery command
 
-If a command fails, inspect current state before retrying. Continue independent steps when safe, but do not claim the bootstrap is complete while a required store operation is pending or failed.
+If a command fails, inspect current state before retrying. Continue independent steps when safe, but do not claim setup is complete while a required store operation is pending or failed.

--- a/revenuecat/skills/integrate-revenuecat/SKILL.md
+++ b/revenuecat/skills/integrate-revenuecat/SKILL.md
@@ -13,7 +13,7 @@ Use this skill when the user wants to add RevenueCat to a project for the first 
 Walk them in order. Most integrations need both halves, even when the user asks "just install the SDK" — the SDK needs an API key from the dashboard.
 
 > If a project + app already exist and the user only wants to wire the SDK into code, jump to **Section 3** below.
-> If the user wants to bootstrap a brand new RevenueCat project (apps + products + entitlements + offerings), use the `create-revenuecat-project` skill instead, then come back here for the SDK install.
+> If the user wants to create and fully configure a new RevenueCat project (apps + products + entitlements + offerings), use the `create-revenuecat-project` skill instead, then come back here for the SDK install.
 
 ## Arguments
 

--- a/revenuecat/skills/revenuecat-store-state/SKILL.md
+++ b/revenuecat/skills/revenuecat-store-state/SKILL.md
@@ -1,18 +1,90 @@
 ---
 name: revenuecat-store-state
-description: Use when the user wants to inspect or change the state of products in App Store Connect or Google Play Console (prices, availability, review screenshots) via the RevenueCat MCP store-state tools
+description: Manage App Store Connect and Google Play product state through RevenueCat, including product creation, prices, availability, localizations, screenshots, and pricing equalization. Use for auditable CLI plan/review/apply workflows or direct RevenueCat MCP store-state operations.
 ---
 
-# Managing product store state
+# Manage product store state
 
-The RevenueCat MCP store-state tools read and write product state — status, pricing, availability, and review metadata — directly in App Store Connect and Google Play Console. Reads are immediate; writes are asynchronous operations that must be polled for completion.
+Use the RevenueCat CLI for creating or bulk-syncing desired store state and whenever a durable, auditable preview is important. Use RevenueCat MCP tools for direct inspection, screenshots, a focused existing-product update, or subscription price equalization. Reads are immediate; writes may be asynchronous.
 
-Refer to the MCP tool schemas for the exact parameters of each tool.
+## CLI: agent-safe plan lifecycle
 
-## Recommended flow
+First inspect the installed command schemas:
 
-1. **Inspect first.** Call `get-product-store-state` to understand the current state of the product before making any change.
-2. **Upload a review screenshot if needed.** If the user has a review screenshot to attach, call `upload-product-store-state-screenshot` before setting the state.
-3. **Apply the change.** Call `set-product-store-state` with the desired changes.
-4. **Poll for completion.** Call `get-product-store-state-operation` until `status` is `succeeded` or `failed`. If the operation fails, report the error details back to the user instead of retrying blindly.
-5. **Equalize territory pricing if warned.** If `warnings` indicates incomplete subscription territory pricing, call `equalize-subscription-prices`.
+```bash
+rc schema products store plan --json
+rc schema products store show --json
+rc schema products store apply --json
+```
+
+The CLI accepts CSV or JSON desired state from a file or stdin and stores the resulting plan in RevenueCat. This requires no repository, `.revenuecat` directory, or local state file.
+
+For an agent, send JSON through stdin and use non-interactive output:
+
+```bash
+rc products store plan <app-id> \
+  --file - \
+  --input-format json \
+  --json \
+  --no-input
+```
+
+The JSON input is either an array of desired states or an object with a `desired_states` array. Use `rc schema products store plan --json` and the command's validation errors to determine the installed version's exact fields.
+
+Capture the returned `data.id`, then inspect that exact persisted plan from a separate process if needed:
+
+```bash
+rc products store show <plan-id> --json --no-input
+```
+
+Review every proposed action and warning. Treat blocker warnings as failures that require user action. Apply only the same plan ID that was reviewed:
+
+```bash
+rc products store apply <plan-id> --yes --json --no-input
+```
+
+If the user rejects it, discard it:
+
+```bash
+rc products store discard <plan-id> --yes --json --no-input
+```
+
+Never run `plan` again between review and apply. A newly generated plan is a different artifact even when the input appears identical. Never add `--yes` until the user or the calling workflow has approved the displayed actions.
+
+### CSV input
+
+CSV is convenient for a customer-maintained catalog. It can contain price and localization rows:
+
+```csv
+row_type,store,store_identifier,product_type,display_name,title,duration,territory,amount,currency,start_date,available,available_in_new_territories,locale,localized_name,localized_description
+price,app_store,com.example.pro_monthly,subscription,Pro Monthly,Premium Monthly,P1M,US,9.99,USD,,true,true,,,
+localization,app_store,com.example.pro_monthly,subscription,Pro Monthly,Premium Monthly,P1M,,,,,,,en-US,Premium Monthly,Monthly premium access
+```
+
+Plan it with:
+
+```bash
+rc products store plan <app-id> --file catalog.csv --json --no-input
+```
+
+For a human working in a TTY, `rc products store sync <app-id>` provides a single-process prompt, review, confirmation, and apply flow. It also accepts `--file catalog.csv`. Agents should use the explicit multi-command lifecycle so approval is attached to a persisted plan ID.
+
+## Store prerequisites
+
+An App Store plan requires configured Apple access. If it is missing, use `rc apps apple check <app-id>` and then hand `rc apps apple setup <app-id>` to the user in their local interactive terminal. Never request Apple credentials or 2FA codes in chat. Apple credentials are sent locally to Apple and are not stored by RevenueCat; generated API keys are uploaded to RevenueCat only after user approval.
+
+Google Play operations require the app's Play credentials to be configured in RevenueCat.
+
+Store-plan syncing may be behind the Khepri feature flag `PRODUCT_CATALOG_PRODUCT_PRICE_MANAGER` while the feature is in development. If the server reports that it is unavailable, report the flag requirement instead of trying to bypass it.
+
+## MCP: direct store-state operations
+
+Refer to each MCP tool schema for exact parameters.
+
+1. Call `get-product-store-state` before changing an existing product.
+2. If review metadata needs a screenshot, call `upload-product-store-state-screenshot` first.
+3. Call `set-product-store-state` with only the approved changes.
+4. Poll `get-product-store-state-operation` until `status` is `succeeded` or `failed`.
+5. If warnings identify incomplete subscription territory pricing, call `equalize-subscription-prices` only after explaining the effect and obtaining approval.
+
+If an operation fails, report its error details and current state. Do not retry blindly or switch from a failed persisted CLI plan to an unreviewed MCP write.


### PR DESCRIPTION
## Summary

- teach `create-revenuecat-project` to use the RevenueCat CLI for complete, idempotent project setup while retaining the MCP fallback
- add fully agentic account creation with explicit Terms consent, generated password, macOS Keychain storage, OAuth verification, and email-verification guidance
- require agents to verify `account_created`, `authenticated`, `password_saved_to_keychain`, and OAuth method before configuring resources
- add the local Apple authentication handoff, including the no-credential-storage disclaimer and explicit human-in-the-loop boundary
- teach `revenuecat-store-state` the durable CLI `plan` → `show` → `apply`/`discard` lifecycle for JSON and CSV desired state
- document agent-safe discovery, JSON output, non-interactive flags, exact plan reuse, current-offering selection, and typed SDK-key retrieval
- make the direct `npx skills` installation example global by default, with project scope as an explicit opt-in
- remove “bootstrap” terminology from the RevenueCat skills

## Why

The CLI can create and authenticate an account, configure the RevenueCat resource graph, and coordinate store setup without requiring local project state. The official skills should direct agents through that workflow while keeping credentials local, requiring explicit legal consent, and keeping mutations reviewable.

## Validation

- validated both modified skills with the skill-creator `quick_validate.py`
- validated all JSON manifests used by CI
- `git diff --check`
- installed the skills from this unmerged branch with `npx skills add` and verified the installed contents

## Test this branch

```bash
npx skills add https://github.com/RevenueCat/ai-toolkit/tree/rc-cli-bootstrap-workflows --global
```
