### PR TITLE
feat(agent-plugins): Add Agent Plugins 1.0.0 support

### DIFF
--- a/.github/workflows/release-gemini.yml
+++ b/.github/workflows/release-gemini.yml
@@ -36,11 +36,16 @@ jobs:
         if: steps.check.outputs.exists == 'false'
         run: |
           # Archive revenuecat/ contents, excluding dot-files and dot-directories.
+          # plugin.json and mcp.json are the portable Agent Plugins manifests and
+          # are not dot-files, so exclude them explicitly — Gemini reads
+          # gemini-extension.json and has no use for them.
           # Run tar from inside revenuecat so '*' expands to real entries there.
           (
             cd revenuecat
             tar -czf /tmp/revenuecat.tar.gz \
               --exclude='.*' \
+              --exclude='plugin.json' \
+              --exclude='mcp.json' \
               *
           )
 

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
-          node-version: '20'
+          node-version: '24'
 
       - name: Validate JSON manifests
         run: |
@@ -39,18 +39,24 @@ jobs:
               || { echo "  INVALID JSON: $f"; exit 1; }
           done
 
-      - name: Install ajv-cli
-        run: npm install -g ajv-cli@5
+      # ajv-cli is a pinned devDependency resolved through the committed
+      # pnpm-lock.yaml, so CI runs the exact, integrity-checked versions we
+      # reviewed. corepack pins pnpm itself via the packageManager field, which
+      # carries an integrity hash. pnpm 11 needs Node >= 22.13, hence Node 24.
+      - name: Install dependencies
+        run: |
+          corepack enable
+          pnpm install --frozen-lockfile
 
       # Blocking: the Agent Plugins 1.0.0 schemas are immutable per spec, so they
       # are vendored under scripts/schemas/ and validated offline.
       - name: Validate Agent Plugins manifests
         run: |
-          ajv validate --spec=draft2020 --strict=false \
+          pnpm exec ajv validate --spec=draft2020 --strict=false \
             -s scripts/schemas/agent-plugins-1.0.0-plugin.schema.json \
             -d revenuecat/plugin.json \
             -d revenuecat-play-billing/plugin.json
-          ajv validate --spec=draft2020 --strict=false \
+          pnpm exec ajv validate --spec=draft2020 --strict=false \
             -s scripts/schemas/agent-plugins-1.0.0-mcp.schema.json \
             -d revenuecat/mcp.json
 
@@ -58,7 +64,7 @@ jobs:
         run: |
           curl -fsSL https://json.schemastore.org/claude-code-marketplace.json -o /tmp/claude-marketplace-schema.json || true
           if [ -f /tmp/claude-marketplace-schema.json ]; then
-            ajv validate -s /tmp/claude-marketplace-schema.json -d .claude-plugin/marketplace.json && echo "Schema valid" || echo "Schema validation failed (non-blocking)"
+            pnpm exec ajv validate -s /tmp/claude-marketplace-schema.json -d .claude-plugin/marketplace.json && echo "Schema valid" || echo "Schema validation failed (non-blocking)"
           else
             echo "Could not fetch schema — skipping schema validation"
           fi

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -23,10 +23,13 @@ jobs:
             .claude-plugin/marketplace.json \
             .cursor-plugin/marketplace.json \
             .agents/plugins/marketplace.json \
+            revenuecat/plugin.json \
+            revenuecat/mcp.json \
             revenuecat/.claude-plugin/plugin.json \
             revenuecat/.cursor-plugin/plugin.json \
             revenuecat/.codex-plugin/plugin.json \
             revenuecat/gemini-extension.json \
+            revenuecat-play-billing/plugin.json \
             revenuecat-play-billing/.claude-plugin/plugin.json \
             revenuecat-play-billing/.cursor-plugin/plugin.json \
             revenuecat-play-billing/.codex-plugin/plugin.json; do
@@ -36,9 +39,23 @@ jobs:
               || { echo "  INVALID JSON: $f"; exit 1; }
           done
 
+      - name: Install ajv-cli
+        run: npm install -g ajv-cli@5
+
+      # Blocking: the Agent Plugins 1.0.0 schemas are immutable per spec, so they
+      # are vendored under scripts/schemas/ and validated offline.
+      - name: Validate Agent Plugins manifests
+        run: |
+          ajv validate --spec=draft2020 --strict=false \
+            -s scripts/schemas/agent-plugins-1.0.0-plugin.schema.json \
+            -d revenuecat/plugin.json \
+            -d revenuecat-play-billing/plugin.json
+          ajv validate --spec=draft2020 --strict=false \
+            -s scripts/schemas/agent-plugins-1.0.0-mcp.schema.json \
+            -d revenuecat/mcp.json
+
       - name: Validate Claude marketplace schema
         run: |
-          npm install -g ajv-cli
           curl -fsSL https://json.schemastore.org/claude-code-marketplace.json -o /tmp/claude-marketplace-schema.json || true
           if [ -f /tmp/claude-marketplace-schema.json ]; then
             ajv validate -s /tmp/claude-marketplace-schema.json -d .claude-plugin/marketplace.json && echo "Schema valid" || echo "Schema validation failed (non-blocking)"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to the RevenueCat AI Toolkit will be documented in this file
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [2.0.0r3] – 2026-08-07
 
 ### Added
 
@@ -14,7 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
-## [2.1.0] - 2026-06-04
+## [2.0.0r2] - 2026-06-04
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to the RevenueCat AI Toolkit will be documented in this file
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- **Agent Plugins 1.0.0 support** — Both plugins now ship a portable [Agent Plugins](https://agent-plugins.org/) manifest at their root (`revenuecat/plugin.json`, `revenuecat-play-billing/plugin.json`), plus `revenuecat/mcp.json` for the RevenueCat MCP server. The existing Claude, Cursor, Codex, and Gemini manifests are unchanged. Note that the Agent Plugins `name` field is lowercase-only, so the portable manifest identifies the main plugin as `revenuecat`
+- CI now validates the portable manifests against the vendored Agent Plugins schemas in `scripts/schemas/` (blocking)
+
+---
+
 ## [2.1.0] - 2026-06-04
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ Gemini has no marketplace and supports a single extension per repository, so it 
 
 ### Visual Studio Code
 
-Plugin marketplace support is currently in beta in Visual Studio Code. Refer to the [instructions](https://code.visualstudio.com/docs/copilot/customization/agent-plugins#_configure-plugin-marketplaces) for how to add this repo as a plugin marketplace, then install the plugin from the marketplace.
+Plugin marketplace support is currently experimental in Visual Studio Code. Refer to the [instructions](https://code.visualstudio.com/docs/copilot/customization/agent-plugins#_configure-plugin-marketplaces) for how to add this repo as a plugin marketplace, then install the plugin from the marketplace.
 
 ### Agent Plugins clients
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Configure RevenueCat projects, products, entitlements, and offerings directly from your AI coding assistant. Access data about your revenue, conversion funnel, and experiments. Manage your in-app purchase monetization without leaving your agent. Works with **Claude Code, Cursor, OpenAI Codex, Visual Studio Code, and Gemini CLI**.
 
-The AI toolkit is distributed as a marketplace (containing a single plugin) for Claude Code, Cursor, Codex, and Visual Studio, and as an extension for Gemini.
+The AI toolkit is distributed as a marketplace (containing a single plugin) for Claude Code, Cursor, Codex, and Visual Studio, and as an extension for Gemini. Both plugins also ship a portable [Agent Plugins 1.0.0](https://agent-plugins.org/) manifest, so any client implementing that standard can load them.
 
 ## Plugins
 
@@ -94,6 +94,15 @@ Gemini has no marketplace and supports a single extension per repository, so it 
 ### Visual Studio Code
 
 Plugin marketplace support is currently in beta in Visual Studio Code. Refer to the [instructions](https://code.visualstudio.com/docs/copilot/customization/agent-plugins#_configure-plugin-marketplaces) for how to add this repo as a plugin marketplace, then install the plugin from the marketplace.
+
+VS Code reads the portable Agent Plugins manifest, so the plugin appears there under its lowercase identifier `revenuecat` (see [Agent Plugins clients](#agent-plugins-clients)).
+
+
+### Agent Plugins clients
+
+Both plugins conform to [Agent Plugins 1.0.0](https://agent-plugins.org/specification): each plugin directory has a root `plugin.json`, its skills under `skills/`, and — for the `RevenueCat` plugin — the MCP server in a root `mcp.json`. Any conformant client can load `revenuecat/` or `revenuecat-play-billing/` directly from a checkout of this repo.
+
+The Agent Plugins `name` field is restricted to lowercase, so the portable manifest identifies the main plugin as `revenuecat` rather than `RevenueCat`. Clients that read the Claude, Cursor, or Codex manifests are unaffected and keep the existing names.
 
 
 ### Other (unsupported agentic coding environments)

--- a/README.md
+++ b/README.md
@@ -95,9 +95,6 @@ Gemini has no marketplace and supports a single extension per repository, so it 
 
 Plugin marketplace support is currently in beta in Visual Studio Code. Refer to the [instructions](https://code.visualstudio.com/docs/copilot/customization/agent-plugins#_configure-plugin-marketplaces) for how to add this repo as a plugin marketplace, then install the plugin from the marketplace.
 
-VS Code reads the portable Agent Plugins manifest, so the plugin appears there under its lowercase identifier `revenuecat` (see [Agent Plugins clients](#agent-plugins-clients)).
-
-
 ### Agent Plugins clients
 
 Both plugins conform to [Agent Plugins 1.0.0](https://agent-plugins.org/specification): each plugin directory has a root `plugin.json`, its skills under `skills/`, and — for the `RevenueCat` plugin — the MCP server in a root `mcp.json`. Any conformant client can load `revenuecat/` or `revenuecat-play-billing/` directly from a checkout of this repo.

--- a/README.md
+++ b/README.md
@@ -97,9 +97,7 @@ Plugin marketplace support is currently in beta in Visual Studio Code. Refer to 
 
 ### Agent Plugins clients
 
-Both plugins conform to [Agent Plugins 1.0.0](https://agent-plugins.org/specification): each plugin directory has a root `plugin.json`, its skills under `skills/`, and — for the `RevenueCat` plugin — the MCP server in a root `mcp.json`. Any conformant client can load `revenuecat/` or `revenuecat-play-billing/` directly from a checkout of this repo.
-
-The Agent Plugins `name` field is restricted to lowercase, so the portable manifest identifies the main plugin as `revenuecat` rather than `RevenueCat`. Clients that read the Claude, Cursor, or Codex manifests are unaffected and keep the existing names.
+Both plugins conform to [Agent Plugins 1.0.0](https://agent-plugins.org/specification): You can install them depending on the client as the `revenuecat` or `revenuecat-play-billing` plugin.
 
 
 ### Other (unsupported agentic coding environments)

--- a/package.json
+++ b/package.json
@@ -14,5 +14,9 @@
   "repository": {
     "type": "git",
     "url": "https://github.com/RevenueCat/ai-toolkit"
-  }
+  },
+  "devDependencies": {
+    "ajv-cli": "5.0.0"
+  },
+  "packageManager": "pnpm@11.20.0+sha512.9a6f330a95b66446ea088faf1521405a8a01f07fde7124cc9958dfed52d4bb436737e65b08f85f37b46fcba375092558ac51262b816844b22f63406ed166bfee"
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,0 +1,202 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    devDependencies:
+      ajv-cli:
+        specifier: 5.0.0
+        version: 5.0.0
+
+packages:
+
+  ajv-cli@5.0.0:
+    resolution: {integrity: sha512-LY4m6dUv44HTyhV+u2z5uX4EhPYTM38Iv1jdgDJJJCyOOuqB8KtZEGjPZ2T+sh5ZIJrXUfgErYx/j3gLd3+PlQ==}
+    hasBin: true
+    peerDependencies:
+      ts-node: '>=9.0.0'
+    peerDependenciesMeta:
+      ts-node:
+        optional: true
+
+  ajv@8.20.0:
+    resolution: {integrity: sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==}
+
+  argparse@1.0.10:
+    resolution: {integrity: sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==}
+
+  balanced-match@1.0.2:
+    resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
+
+  brace-expansion@1.1.18:
+    resolution: {integrity: sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==}
+
+  concat-map@0.0.1:
+    resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
+
+  esprima@4.0.1:
+    resolution: {integrity: sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==}
+    engines: {node: '>=4'}
+    hasBin: true
+
+  fast-deep-equal@2.0.1:
+    resolution: {integrity: sha512-bCK/2Z4zLidyB4ReuIsvALH6w31YfAQDmXMqMx6FyfHqvBxtjC0eRumeSu4Bs3XtXwpyIywtSTrVT99BxY1f9w==}
+
+  fast-deep-equal@3.1.3:
+    resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
+
+  fast-json-patch@2.2.1:
+    resolution: {integrity: sha512-4j5uBaTnsYAV5ebkidvxiLUYOwjQ+JSFljeqfTxCrH9bDmlCQaOJFS84oDJ2rAXZq2yskmk3ORfoP9DCwqFNig==}
+    engines: {node: '>= 0.4.0'}
+
+  fast-uri@3.1.5:
+    resolution: {integrity: sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==}
+
+  fs.realpath@1.0.0:
+    resolution: {integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==}
+
+  glob@7.2.3:
+    resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
+
+  inflight@1.0.6:
+    resolution: {integrity: sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==}
+    deprecated: This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.
+
+  inherits@2.0.4:
+    resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
+
+  js-yaml@3.15.1:
+    resolution: {integrity: sha512-S99WuO3HlhO3XN41EtYUNl9zzXjoJx7QvmipxsJVxtCBT0YHEFy+iOJhjSvrmV12nYhWpZaM8lPHkJm0yUMbag==}
+    hasBin: true
+
+  json-schema-migrate@2.0.0:
+    resolution: {integrity: sha512-r38SVTtojDRp4eD6WsCqiE0eNDt4v1WalBXb9cyZYw9ai5cGtBwzRNWjHzJl38w6TxFkXAIA7h+fyX3tnrAFhQ==}
+
+  json-schema-traverse@1.0.0:
+    resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==}
+
+  json5@2.2.3:
+    resolution: {integrity: sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==}
+    engines: {node: '>=6'}
+    hasBin: true
+
+  minimatch@3.1.5:
+    resolution: {integrity: sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==}
+
+  minimist@1.2.8:
+    resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
+
+  once@1.4.0:
+    resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
+
+  path-is-absolute@1.0.1:
+    resolution: {integrity: sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==}
+    engines: {node: '>=0.10.0'}
+
+  require-from-string@2.0.2:
+    resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
+    engines: {node: '>=0.10.0'}
+
+  sprintf-js@1.0.3:
+    resolution: {integrity: sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==}
+
+  wrappy@1.0.2:
+    resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
+
+snapshots:
+
+  ajv-cli@5.0.0:
+    dependencies:
+      ajv: 8.20.0
+      fast-json-patch: 2.2.1
+      glob: 7.2.3
+      js-yaml: 3.15.1
+      json-schema-migrate: 2.0.0
+      json5: 2.2.3
+      minimist: 1.2.8
+
+  ajv@8.20.0:
+    dependencies:
+      fast-deep-equal: 3.1.3
+      fast-uri: 3.1.5
+      json-schema-traverse: 1.0.0
+      require-from-string: 2.0.2
+
+  argparse@1.0.10:
+    dependencies:
+      sprintf-js: 1.0.3
+
+  balanced-match@1.0.2: {}
+
+  brace-expansion@1.1.18:
+    dependencies:
+      balanced-match: 1.0.2
+      concat-map: 0.0.1
+
+  concat-map@0.0.1: {}
+
+  esprima@4.0.1: {}
+
+  fast-deep-equal@2.0.1: {}
+
+  fast-deep-equal@3.1.3: {}
+
+  fast-json-patch@2.2.1:
+    dependencies:
+      fast-deep-equal: 2.0.1
+
+  fast-uri@3.1.5: {}
+
+  fs.realpath@1.0.0: {}
+
+  glob@7.2.3:
+    dependencies:
+      fs.realpath: 1.0.0
+      inflight: 1.0.6
+      inherits: 2.0.4
+      minimatch: 3.1.5
+      once: 1.4.0
+      path-is-absolute: 1.0.1
+
+  inflight@1.0.6:
+    dependencies:
+      once: 1.4.0
+      wrappy: 1.0.2
+
+  inherits@2.0.4: {}
+
+  js-yaml@3.15.1:
+    dependencies:
+      argparse: 1.0.10
+      esprima: 4.0.1
+
+  json-schema-migrate@2.0.0:
+    dependencies:
+      ajv: 8.20.0
+
+  json-schema-traverse@1.0.0: {}
+
+  json5@2.2.3: {}
+
+  minimatch@3.1.5:
+    dependencies:
+      brace-expansion: 1.1.18
+
+  minimist@1.2.8: {}
+
+  once@1.4.0:
+    dependencies:
+      wrappy: 1.0.2
+
+  path-is-absolute@1.0.1: {}
+
+  require-from-string@2.0.2: {}
+
+  sprintf-js@1.0.3: {}
+
+  wrappy@1.0.2: {}

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/SchemaStore/schemastore/refs/heads/master/src/schemas/json/pnpm-workspace.json
+
+minimumReleaseAge: 4320 # 3 days
+minimumReleaseAgeExclude:
+  - '@revenuecat/*'
+
+saveExact: true

--- a/revenuecat-play-billing/plugin.json
+++ b/revenuecat-play-billing/plugin.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
+  "name": "revenuecat-play-billing",
+  "version": "1.0.0",
+  "description": "Deep Google Play subscription lifecycle skills for the RevenueCat Android SDK — purchases, plan and price changes, payment recovery, webhooks, security.",
+  "author": {
+    "name": "RevenueCat",
+    "email": "support@revenuecat.com",
+    "url": "https://www.revenuecat.com"
+  },
+  "homepage": "https://www.revenuecat.com/guides/revenuecat-android-sdk",
+  "repository": "https://github.com/RevenueCat/ai-toolkit",
+  "license": "Apache-2.0",
+  "keywords": ["revenuecat", "android", "google-play", "play-billing", "subscriptions", "iap"]
+}

--- a/revenuecat/mcp.json
+++ b/revenuecat/mcp.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "https://agent-plugins.org/schemas/1.0.0/mcp.schema.json",
+  "mcpServers": {
+    "RevenueCat": {
+      "type": "streamable-http",
+      "url": "https://mcp.revenuecat.ai/mcp"
+    }
+  }
+}

--- a/revenuecat/plugin.json
+++ b/revenuecat/plugin.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
+  "name": "revenuecat",
+  "version": "2.0.0",
+  "description": "Set up RevenueCat, integrate it, and access data.",
+  "author": {
+    "name": "RevenueCat",
+    "email": "support@revenuecat.com",
+    "url": "https://www.revenuecat.com"
+  },
+  "homepage": "https://www.revenuecat.com",
+  "repository": "https://github.com/RevenueCat/ai-toolkit",
+  "license": "MIT",
+  "keywords": ["revenuecat", "in-app-purchases", "subscriptions", "monetization", "iap", "mcp"]
+}

--- a/scripts/schemas/agent-plugins-1.0.0-mcp.schema.json
+++ b/scripts/schemas/agent-plugins-1.0.0-mcp.schema.json
@@ -1,0 +1,120 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://agent-plugins.org/schemas/1.0.0/mcp.schema.json",
+  "title": "Agent Plugins MCP Configuration",
+  "description": "Machine-readable schema for mcp.json in Agent Plugins 1.0.0. The Agent Plugins specification defines additional semantic and operational requirements.",
+  "type": "object",
+  "properties": {
+    "$schema": {
+      "const": "https://agent-plugins.org/schemas/1.0.0/mcp.schema.json",
+      "description": "Canonical identifier of the MCP configuration schema for the Agent Plugins version targeted by this document."
+    },
+    "mcpServers": {
+      "type": "object",
+      "additionalProperties": {
+        "$ref": "#/$defs/server"
+      }
+    }
+  },
+  "required": ["$schema", "mcpServers"],
+  "additionalProperties": false,
+  "$defs": {
+    "server": {
+      "title": "MCP server",
+      "oneOf": [
+        {
+          "$ref": "#/$defs/stdioServer"
+        },
+        {
+          "$ref": "#/$defs/streamableHttpServer"
+        },
+        {
+          "$ref": "#/$defs/sseServer"
+        }
+      ]
+    },
+    "stdioServer": {
+      "title": "stdio MCP server",
+      "type": "object",
+      "properties": {
+        "type": {
+          "const": "stdio"
+        },
+        "command": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Executable token. Resolution rules are defined by the Agent Plugins specification."
+        },
+        "args": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "env": {
+          "type": "object",
+          "propertyNames": {
+            "not": {
+              "enum": ["PLUGIN_ROOT", "PLUGIN_DATA"]
+            }
+          },
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "cwd": {
+          "type": "string",
+          "pattern": "^(?:\\./|\\$\\{PLUGIN_ROOT\\}(?:/|$)|\\$\\{PLUGIN_DATA\\}(?:/|$))",
+          "description": "Plugin-relative, PLUGIN_ROOT-rooted, or PLUGIN_DATA-rooted working directory. Filesystem containment is validated separately."
+        }
+      },
+      "required": ["type", "command"],
+      "additionalProperties": false
+    },
+    "streamableHttpServer": {
+      "title": "Streamable HTTP MCP server",
+      "type": "object",
+      "properties": {
+        "type": {
+          "const": "streamable-http"
+        },
+        "url": {
+          "type": "string",
+          "minLength": 1,
+          "description": "MCP endpoint URL. URL semantics are defined by the Agent Plugins specification."
+        },
+        "headers": {
+          "$ref": "#/$defs/headers"
+        }
+      },
+      "required": ["type", "url"],
+      "additionalProperties": false
+    },
+    "sseServer": {
+      "title": "Legacy HTTP+SSE MCP server",
+      "type": "object",
+      "properties": {
+        "type": {
+          "const": "sse"
+        },
+        "url": {
+          "type": "string",
+          "minLength": 1,
+          "description": "MCP endpoint URL. URL semantics are defined by the Agent Plugins specification."
+        },
+        "headers": {
+          "$ref": "#/$defs/headers"
+        }
+      },
+      "required": ["type", "url"],
+      "additionalProperties": false
+    },
+    "headers": {
+      "title": "HTTP headers",
+      "type": "object",
+      "additionalProperties": {
+        "type": "string"
+      }
+    }
+  }
+}

--- a/scripts/schemas/agent-plugins-1.0.0-plugin.schema.json
+++ b/scripts/schemas/agent-plugins-1.0.0-plugin.schema.json
@@ -1,0 +1,65 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
+  "title": "Agent Plugins Manifest",
+  "description": "Machine-readable schema for plugin.json in Agent Plugins 1.0.0. The Agent Plugins specification defines additional semantic and operational requirements.",
+  "type": "object",
+  "properties": {
+    "$schema": {
+      "const": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
+      "description": "Canonical identifier of the plugin manifest schema for the Agent Plugins version targeted by this document."
+    },
+    "name": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 64,
+      "pattern": "^(?!.*(?:--|\\.\\.))[a-z0-9](?:[a-z0-9.-]*[a-z0-9])?$",
+      "description": "Human-readable plugin name."
+    },
+    "version": {
+      "type": "string"
+    },
+    "description": {
+      "type": "string"
+    },
+    "author": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "email": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false
+    },
+    "homepage": {
+      "type": "string"
+    },
+    "repository": {
+      "type": "string"
+    },
+    "license": {
+      "type": "string"
+    },
+    "keywords": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "extensions": {
+      "type": "object",
+      "description": "Client-specific manifest data keyed by reverse-domain extension namespace. Agent Plugins assigns no semantics to namespace object contents.",
+      "additionalProperties": {
+        "type": "object"
+      }
+    }
+  },
+  "required": ["$schema", "name"],
+  "additionalProperties": false
+}


### PR DESCRIPTION
Adds support for [Agent Plugins 1.0.0](https://agent-plugins.org/), the vendor-neutral standard for packaging skills and MCP servers (Vercel-initiated; TSC from AWS, Cursor, Microsoft, OpenAI, Vercel). The spec standardizes the plugin package only — it says nothing about marketplaces, so all three marketplace files stay as they are.

<details>
<summary>Details</summary>

## What's added

| File | Purpose |
|---|---|
| `revenuecat/plugin.json` | Portable manifest |
| `revenuecat/mcp.json` | RevenueCat MCP server, portable form |
| `revenuecat-play-billing/plugin.json` | Portable manifest |
| `scripts/schemas/*.json` | Vendored spec schemas for offline CI validation |

Our existing `skills/{slug}/SKILL.md` layout already matched the spec exactly, so no skills were touched.

Nothing existing was modified: `.claude-plugin/`, `.cursor-plugin/`, `.codex-plugin/`, `gemini-extension.json`, `.mcp.json`, and the three `marketplace.json` files are all unchanged.

## Notable spec constraints

- **`name` is lowercase-only** and there is no `displayName` field, so the portable manifest identifies the main plugin as `revenuecat` rather than `RevenueCat`. Clients reading the Claude, Cursor, or Codex manifests keep the existing names, so `claude plugins install RevenueCat` and the Cursor marketplace listing are unaffected.
- **The manifest schema is closed.** The Codex/Cursor extras (`skills`, `mcpServers`, `logo`, `interface`) are illegal top-level keys here and stay in their client-specific manifests.
- **`mcp.json` differs from our `.mcp.json` in three ways:** `$schema` is required, `type: "http"` becomes `"streamable-http"` (the spec has no `http` transport), and the server-level `description` key is disallowed.

## CI

`validate.yml` gets the three new files in the JSON-parse loop plus a **blocking** ajv step against the vendored schemas. The spec declares schema identifiers immutable, so vendoring lets this run offline rather than depending on a network fetch like the existing (non-blocking) schemastore check. `ajv-cli` is now pinned to v5 and installed once.

`release-gemini.yml` excludes the two new manifests from the tarball — they aren't dot-files, so they'd otherwise have been swept into the Gemini extension. The shipped archive is content-identical to today's.

## Verification

Run locally:

- All 13 manifests parse; both `plugin.json`s and `mcp.json` validate clean against the vendored schemas.
- The gate genuinely fails on the two violations it exists to catch: `name: "RevenueCat"` → pattern error, and `type: "http"` + `description` → oneOf/additionalProperties error.
- The Gemini tar produces exactly `assets/`, `gemini-extension.json`, `README.md`, `skills/`.

**Not verified — worth a manual check before merge:** VS Code resolves the Agent Plugins manifest ahead of `.claude-plugin/plugin.json`, so this changes which manifest it reads for this repo (it will now show `revenuecat` and read `mcp.json` instead of `.mcp.json`). Installing from this branch into VS Code and Codex once would confirm no regression.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PsBTbTdaQnAYQN4Vwof1e3
