### PR TITLE
fix(agents-marketplace): agents/marketplace.json to fix codex/agents spec installation

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -2,7 +2,7 @@
   "name": "RevenueCat",
   "plugins": [
     {
-      "name": "RevenueCat",
+      "name": "revenuecat",
       "source": { "source": "local", "path": "./revenuecat" },
       "policy": { "installation": "AVAILABLE", "authentication": "ON_INSTALL" },
       "category": "Productivity"


### PR DESCRIPTION
Here's a screenshot showing a mismatch in marketplace.json that's preventing installing the RevenueCat plugin in Codex.

https://github.com/user-attachments/assets/20485428-1c03-44f2-a009-4dc60e7c5ba3

This small change fixes the wiring and brings the Codex installation back to life.

https://github.com/user-attachments/assets/42ebc1eb-2ba2-4020-9b99-c78815b4d91f

I think this change shouldn't broke any scenario in claude code nor cursor, or other agents. 

