### PR TITLE
fix: rename revenuecat plugin to kebab-case with migration path

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,12 +6,14 @@
     "name": "RevenueCat",
     "email": "support@revenuecat.com"
   },
+  "renames": { "RevenueCat": "revenuecat" },
   "plugins": [
     {
-      "name": "RevenueCat",
+      "name": "revenuecat",
+      "displayName": "RevenueCat",
       "source": "./revenuecat",
       "description": "Set up RevenueCat, integrate it, and access data.",
-      "version": "2.0.0",
+      "version": "2.0.1",
       "category": "developer-tools",
       "author": { "name": "RevenueCat" },
       "homepage": "https://www.revenuecat.com",

--- a/README.md
+++ b/README.md
@@ -24,13 +24,13 @@ From within Claude Code
 ```
 /plugin
 ```
-Then select `Marketplace`, `+ Add Marketplace`, enter `RevenueCat/ai-toolkit`. Then, select the `RevenueCat` plugin. If you ship Android and want handbook-level Google Play depth, also select `revenuecat-play-billing`.
+Then select `Marketplace`, `+ Add Marketplace`, enter `RevenueCat/ai-toolkit`. Then, select the `revenuecat` plugin. If you ship Android and want handbook-level Google Play depth, also select `revenuecat-play-billing`.
 
 Or from the command line:
 
 ```
 claude plugins marketplace add RevenueCat/ai-toolkit
-claude plugins install RevenueCat
+claude plugins install revenuecat
 claude plugins install revenuecat-play-billing
 ```
 
@@ -49,7 +49,7 @@ You can add the RevenueCat AI Toolkit to Cursor from the [Cursor Marketplace](ht
 codex plugin marketplace add RevenueCat/ai-toolkit
 ```
 
-Start Codex, then run `/plugins`, search for `RevenueCat`, and install.
+Start Codex, then run `/plugins`, search for `revenuecat`, and install.
 
 Installing the plugin does not trigger authentication automatically. If the RevenueCat MCP server shows as "Not logged in", run:
 
@@ -74,6 +74,8 @@ Installing the plugin does not trigger authentication automatically. If the Reve
 codex mcp login RevenueCat
 ```
 
+**Upgrading from v2.0.0 or earlier (Codex CLI and Desktop App):** The plugin was renamed from `RevenueCat` to `revenuecat` in v2.0.1. A previously installed `RevenueCat` plugin keeps working from Codex's local cache but no longer receives updates. To get back on the update path, open `/plugins`, uninstall `RevenueCat`, and install `revenuecat`. Your MCP server login is preserved — no need to run `codex mcp login` again.
+
 **Troubleshooting (Codex CLI and Desktop App):** If the RevenueCat MCP server disappears from Settings or the agent loses access to RevenueCat tools after restarting Codex, you are hitting a known Codex issue with reloading plugin-provided MCP servers ([openai/codex#25809](https://github.com/openai/codex/issues/25809)). As a workaround, register the MCP server globally — the plugin's skills keep working, and the server survives restarts:
 
 ```bash
@@ -88,7 +90,7 @@ codex mcp login RevenueCat
 gemini extensions install https://github.com/RevenueCat/ai-toolkit
 ```
 
-Gemini has no marketplace and supports a single extension per repository, so it installs the `RevenueCat` plugin only. The `revenuecat-play-billing` plugin is available on Claude Code, Cursor, Codex, and VS Code.
+Gemini has no marketplace and supports a single extension per repository, so it installs the `revenuecat` plugin only. The `revenuecat-play-billing` plugin is available on Claude Code, Cursor, Codex, and VS Code.
 
 
 ### Visual Studio Code

--- a/revenuecat/.claude-plugin/plugin.json
+++ b/revenuecat/.claude-plugin/plugin.json
@@ -1,7 +1,8 @@
 {
-	"name": "RevenueCat",
+	"name": "revenuecat",
+	"displayName": "RevenueCat",
 	"description": "Set up RevenueCat, integrate it, and access data.",
-	"version": "2.0.0",
+	"version": "2.0.1",
 	"license": "MIT",
 	"keywords": ["revenuecat", "in-app-purchases", "subscriptions", "monetization", "iap", "mcp"],	
 	"author": {

--- a/revenuecat/.codex-plugin/plugin.json
+++ b/revenuecat/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
-  "name": "RevenueCat",
-  "version": "2.0.0",
+  "name": "revenuecat",
+  "version": "2.0.1",
   "description": "Configure your RevenueCat integration and access data from your RevenueCat projects.",
   "homepage": "https://www.revenuecat.com/docs/tools/mcp/overview",
   "repository": "https://github.com/RevenueCat/ai-toolkit",

--- a/revenuecat/.cursor-plugin/plugin.json
+++ b/revenuecat/.cursor-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "revenuecat",
   "description": "Configure your RevenueCat integration and access data from your RevenueCat projects.",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "license": "MIT",
   "keywords": ["revenuecat", "in-app-purchases", "subscriptions", "monetization", "iap", "mcp"],
   "author": {

--- a/revenuecat/gemini-extension.json
+++ b/revenuecat/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "revenuecat",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Configure RevenueCat projects, products, entitlements, and offerings from Gemini CLI.",
   "mcpServers": {
     "revenuecat": {

--- a/revenuecat/plugin.json
+++ b/revenuecat/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
   "name": "revenuecat",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Set up RevenueCat, integrate it, and access data.",
   "author": {
     "name": "RevenueCat",


### PR DESCRIPTION
## Why

Claude Desktop / claude.ai marketplace sync silently drops plugin entries whose name is not kebab-case — this is why the `RevenueCat` plugin card was missing when adding this repo as a marketplace in Claude Desktop (and the same mismatch affects our entries in `anthropics/claude-plugins-official`, which pin a pre-rename SHA). Codex's Agent Plugins 1.0.0 manifest validation also requires lowercase names, so the capitalized name was already latent breakage there.

Fixes [RICO-412](https://linear.app/revenuecat/issue/RICO-412/rename-ai-toolkit-plugin-to-kebab-case-everywhere). Context: [Slack thread](https://revenuecat.slack.com/archives/C0AEZUTQD2B/p1785300338344439).

## What

- Plugin name `RevenueCat` → `revenuecat` in the three manifests that were still capitalized: the plugin entry in `.claude-plugin/marketplace.json`, `revenuecat/.claude-plugin/plugin.json`, and `revenuecat/.codex-plugin/plugin.json`. (Cursor, Gemini, and the Agent Plugins manifests were already lowercase.)
- Top-level `"renames": { "RevenueCat": "revenuecat" }` in the Claude marketplace manifest, plus `"displayName": "RevenueCat"` so branding is preserved in all UI surfaces.
- Version bump `2.0.0` → `2.0.1` across all `revenuecat` plugin manifests (the update signal for Codex users).
- README: install commands updated to `revenuecat`; added an upgrade note to the Codex section.

## Migration impact

- **Claude Code**: fully automatic via `renames` — the plugin uses a relative-path source, so existing installs migrate with no reinstall (one-time notice). Requires Claude Code ≥ 2.1.193; older CLIs will report plugin-not-found.
- **Marketplace-level `name` deliberately stays `"RevenueCat"`**: Claude Desktop accepts any-case letters for *marketplace* names (verified via `claude plugin validate` — the strict kebab-case rule applies only to *plugin* names), and there is no renames mechanism for marketplace names, so changing it would strand every existing `RevenueCat@RevenueCat` registration and defeat the migration.
- **Codex**: no rename mechanism exists (verified against `openai/codex` source). Existing `RevenueCat` installs keep working from Codex's local cache but stop receiving updates; the README documents the one-time uninstall/install via `/plugins`. The MCP server key in `.mcp.json` deliberately stays `"RevenueCat"` — Codex keys OAuth credentials by server name + URL, so **users will not need to re-run `codex mcp login`**.
- **Gemini / Cursor**: no identifier change, version bump only.

## Follow-ups (not in this PR)

- After merge, ask Anthropic (via the official submission form) to remove the duplicate `rc` entry in `claude-plugins-official`, refresh the pinned SHA for the `revenuecat` entry, and update the source URL from `rc-claude-code-plugin.git` to `ai-toolkit.git`.
- Optional Codex nudge for stale installs (deprecation stub under the old name) if adoption of the new name lags.

## Validation

- `claude plugin validate .` passes (including `renames` chain integrity).
- All JSON manifests pass the repo's CI checks (ajv against the vendored Agent Plugins 1.0.0 schemas).

🤖 Generated with [Claude Code](https://claude.com/claude-code)