### PR TITLE
docs: fix remaining plugin name reference in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ This marketplace ships two plugins:
 | `RevenueCat` | The RevenueCat MCP server (project configuration and data access) plus cross-platform integration skills for iOS, Android, Kotlin Multiplatform, Flutter, and React Native. |
 | `revenuecat-play-billing` | Deep Google Play subscription lifecycle skills for the RevenueCat Android SDK — purchases, plan and price changes, payment recovery, webhooks, security. Synced from [RevenueCat/play-billing-skills](https://github.com/RevenueCat/play-billing-skills), which is the source of truth. |
 
-Most users want the `RevenueCat` plugin. Add `revenuecat-play-billing` on top if you ship Android and want handbook-level depth on Google Play billing behavior.
+Most users want the `revenuecat` plugin. Add `revenuecat-play-billing` on top if you ship Android and want handbook-level depth on Google Play billing behavior.
 
 ## Installation
 


### PR DESCRIPTION
One backticked plugin-name reference was missed in #43: "Most users want the `RevenueCat` plugin" → `revenuecat`. Follow-up to [RICO-412](https://linear.app/revenuecat/issue/RICO-412/rename-ai-toolkit-plugin-to-kebab-case-everywhere).

🤖 Generated with [Claude Code](https://claude.com/claude-code)