### PR TITLE
fix: add root plugin manifest so official-catalog installs work

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,0 +1,18 @@
+{
+	"_comment": "Workaround for the anthropics/claude-plugins-official catalog: its 'revenuecat' entry uses a 'url' source with a 'path' field, but Claude Code ignores 'path' for url sources and installs the REPO ROOT as the plugin (empty: no skills, no MCP). This manifest makes the repo root a valid plugin by pointing at the components in ./revenuecat, so official-catalog installs work. Keep 'version' in sync with revenuecat/.claude-plugin/plugin.json. Delete this file once the catalog entry is fixed to use a 'git-subdir' source.",
+	"name": "revenuecat",
+	"displayName": "RevenueCat",
+	"description": "Set up RevenueCat, integrate it, and access data.",
+	"version": "2.0.1",
+	"license": "MIT",
+	"keywords": ["revenuecat", "in-app-purchases", "subscriptions", "monetization", "iap", "mcp"],
+	"author": {
+		"name": "RevenueCat",
+		"url": "https://www.revenuecat.com",
+		"email": "support@revenuecat.com"
+	},
+	"homepage": "https://www.revenuecat.com",
+	"repository": "https://github.com/RevenueCat/ai-toolkit",
+	"skills": ["./revenuecat/skills"],
+	"mcpServers": "./revenuecat/.mcp.json"
+}


### PR DESCRIPTION
## Problem

Installing `revenuecat` from `anthropics/claude-plugins-official` (e.g. via the Claude Desktop Directory) yields an **empty plugin** — no skills, no MCP server.

Root cause, verified by local reproduction: the official catalog entry uses a `"url"` source with `"path": "revenuecat"`, but Claude Code **ignores `path` for url sources** and installs the **repo root** as the plugin. The repo root had no plugin manifest, so the installer synthesized a stub from catalog metadata, and there are no skills at the root. This is independent of the kebab-case rename (#43) — it reproduces at current main, so Anthropic's periodic SHA bump alone would not fix it.

## Fix

Make the repo root a valid plugin: add `.claude-plugin/plugin.json` pointing at the real components via the documented custom-path fields (`"skills": ["./revenuecat/skills"]` adds to the default scan; `"mcpServers"` accepts a config file path). A `_comment` field in the manifest explains why it exists, and that it should be deleted once the catalog entry is fixed properly.

Verified locally by mimicking the exact official source shape (`url` + `path` + `sha`) against this branch:
- the installer uses this manifest (no synthesis), cache keyed by version
- all 16 skills load in a fresh session (checked with every other installed copy disabled)
- the MCP server registers (`plugin:revenuecat:RevenueCat`)
- `claude plugin validate .` passes; a directory being both marketplace and plugin is documented as supported
- our own marketplace path is unaffected (entries resolve `./revenuecat` directly and never read this file)

## Caveats

- Official installs only pick this up once Anthropic's sync bumps the pinned `sha` past this commit (observed to happen automatically within days).
- This is a workaround. The proper fix is on Anthropic's side: switch the catalog entry to a `"git-subdir"` source (verified locally to scope correctly, even at the currently pinned SHA), remove the duplicate `rc` entry, and update the source URL from `rc-claude-code-plugin.git` to `ai-toolkit.git`. Once that lands, this root manifest can be deleted.
- One more manifest whose `version` must be kept in sync with `revenuecat/.claude-plugin/plugin.json`.

Part of [RICO-412](https://linear.app/revenuecat/issue/RICO-412/rename-ai-toolkit-plugin-to-kebab-case-everywhere) follow-up. Context: [Slack thread](https://revenuecat.slack.com/archives/C0AEZUTQD2B/p1785300338344439).

🤖 Generated with [Claude Code](https://claude.com/claude-code)