### PR TITLE
Update store-state skill for GA, bump to 2.1.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,7 +13,7 @@
       "displayName": "RevenueCat",
       "source": "./revenuecat",
       "description": "Set up RevenueCat, integrate it, and access data.",
-      "version": "2.0.1",
+      "version": "2.1.0",
       "category": "developer-tools",
       "author": { "name": "RevenueCat" },
       "homepage": "https://www.revenuecat.com",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -3,7 +3,7 @@
 	"name": "revenuecat",
 	"displayName": "RevenueCat",
 	"description": "Set up RevenueCat, integrate it, and access data.",
-	"version": "2.0.1",
+	"version": "2.1.0",
 	"license": "MIT",
 	"keywords": ["revenuecat", "in-app-purchases", "subscriptions", "monetization", "iap", "mcp"],
 	"author": {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to the RevenueCat AI Toolkit will be documented in this file
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.1.0] – 2026-08-21
+
+### Added
+
+- **Store-state product management is now generally available** — The RevenueCat MCP server's store-state tools (`get-product-store-state`, `set-product-store-state`, `get-product-store-state-operation`, `upload-product-store-state-screenshot`, `create-product-prices`, `equalize-subscription-prices`, `submit-products-to-store`) let agents inspect and change product state — prices, availability, review metadata — directly in App Store Connect and Google Play Console
+
+### Changed
+
+- **revenuecat-store-state** skill updated for the GA tool set: covers `create-product-prices` and `submit-products-to-store`, documents the store-credentials prerequisite, and instructs agents to show a before → after summary and get explicit user confirmation before production-store writes (price changes on live products, availability removal, store submission)
+
+---
+
 ## [2.0.0r3] – 2026-08-07
 
 ### Added

--- a/revenuecat/.claude-plugin/plugin.json
+++ b/revenuecat/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
 	"name": "revenuecat",
 	"displayName": "RevenueCat",
 	"description": "Set up RevenueCat, integrate it, and access data.",
-	"version": "2.0.1",
+	"version": "2.1.0",
 	"license": "MIT",
 	"keywords": ["revenuecat", "in-app-purchases", "subscriptions", "monetization", "iap", "mcp"],	
 	"author": {

--- a/revenuecat/.codex-plugin/plugin.json
+++ b/revenuecat/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "revenuecat",
-  "version": "2.0.1",
+  "version": "2.1.0",
   "description": "Configure your RevenueCat integration and access data from your RevenueCat projects.",
   "homepage": "https://www.revenuecat.com/docs/tools/mcp/overview",
   "repository": "https://github.com/RevenueCat/ai-toolkit",

--- a/revenuecat/.cursor-plugin/plugin.json
+++ b/revenuecat/.cursor-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "revenuecat",
   "description": "Configure your RevenueCat integration and access data from your RevenueCat projects.",
-  "version": "2.0.1",
+  "version": "2.1.0",
   "license": "MIT",
   "keywords": ["revenuecat", "in-app-purchases", "subscriptions", "monetization", "iap", "mcp"],
   "author": {

--- a/revenuecat/README.md
+++ b/revenuecat/README.md
@@ -49,6 +49,23 @@ Claude: RevenueCat Project Status
         ✅ Configuration looks healthy!
 ```
 
+### Store Product Management
+
+```
+You: Raise the price of my annual plan to $89.99 on the App Store
+
+Claude: [reads current store state]
+        rc_annual — currently $79.99 (USD base), live in 175 territories
+        Proposed: $89.99 base price, other territories equalized by Apple
+
+        This changes what live customers pay. Apply?
+
+You: Yes
+
+Claude: [applies the change and polls the operation]
+        Done — the new price is live in App Store Connect.
+```
+
 ## MCP
 
 This plugin contains the RevenueCat MCP server setup and uses it to access your RevenueCat projects.

--- a/revenuecat/gemini-extension.json
+++ b/revenuecat/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "revenuecat",
-  "version": "2.0.1",
+  "version": "2.1.0",
   "description": "Configure RevenueCat projects, products, entitlements, and offerings from Gemini CLI.",
   "mcpServers": {
     "revenuecat": {

--- a/revenuecat/plugin.json
+++ b/revenuecat/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
   "name": "revenuecat",
-  "version": "2.0.1",
+  "version": "2.1.0",
   "description": "Set up RevenueCat, integrate it, and access data.",
   "author": {
     "name": "RevenueCat",

--- a/revenuecat/skills/revenuecat-store-state/SKILL.md
+++ b/revenuecat/skills/revenuecat-store-state/SKILL.md
@@ -11,7 +11,7 @@ Refer to the MCP tool schemas for the exact parameters of each tool.
 
 ## Prerequisites
 
-Store-state writes require store credentials connected to the RevenueCat project (an App Store Connect API key or a Google Play service account) and a RevenueCat login with write access to the project. If a write fails with a credentials or permission error, report what is missing and how to fix it (dashboard app settings for store credentials) instead of retrying.
+Store-state writes require store credentials connected to the RevenueCat project (an App Store Connect API key, or a Google Play service account with the **Manage store presence** permission) and a RevenueCat login with write access to the project. If a write fails with a credentials or permission error, report what is missing and how to fix it (dashboard app settings for store credentials) instead of retrying.
 
 ## Confirm before writing
 

--- a/revenuecat/skills/revenuecat-store-state/SKILL.md
+++ b/revenuecat/skills/revenuecat-store-state/SKILL.md
@@ -9,10 +9,27 @@ The RevenueCat MCP store-state tools read and write product state — status, pr
 
 Refer to the MCP tool schemas for the exact parameters of each tool.
 
+## Prerequisites
+
+Store-state writes require store credentials connected to the RevenueCat project (an App Store Connect API key or a Google Play service account) and a RevenueCat login with write access to the project. If a write fails with a credentials or permission error, report what is missing and how to fix it (dashboard app settings for store credentials) instead of retrying.
+
+## Confirm before writing
+
+Store-state writes go straight to production stores and can change what live customers see and pay. Before any of the following, show the user a compact before → after summary of the exact change (based on a fresh `get-product-store-state` read) and proceed only after they explicitly confirm:
+
+- Price changes on a live product
+- Removing availability or territories
+- Submitting products for store review
+
+Confirm each product's change individually or as one clearly itemized batch — never fold unrelated changes into a single confirmation. Reads, review-screenshot uploads, and writes to Test Store or RC Billing products do not need confirmation.
+
 ## Recommended flow
 
 1. **Inspect first.** Call `get-product-store-state` to understand the current state of the product before making any change.
-2. **Upload a review screenshot if needed.** If the user has a review screenshot to attach, call `upload-product-store-state-screenshot` before setting the state.
-3. **Apply the change.** Call `set-product-store-state` with the desired changes.
-4. **Poll for completion.** Call `get-product-store-state-operation` until `status` is `succeeded` or `failed`. If the operation fails, report the error details back to the user instead of retrying blindly.
-5. **Equalize territory pricing if warned.** If `warnings` indicates incomplete subscription territory pricing, call `equalize-subscription-prices`.
+2. **Configure prices if needed.** Call `create-product-prices` to set up prices for a product that does not have them yet.
+3. **Upload a review screenshot if needed.** If the user has a review screenshot to attach, call `upload-product-store-state-screenshot` before setting the state.
+4. **Confirm with the user.** For the write types listed above, show the before → after summary and wait for an explicit go-ahead.
+5. **Apply the change.** Call `set-product-store-state` with the desired changes.
+6. **Poll for completion.** Call `get-product-store-state-operation` until `status` is `succeeded` or `failed`. If the operation fails, report the error details back to the user instead of retrying blindly.
+7. **Equalize territory pricing if warned.** If `warnings` indicates incomplete subscription territory pricing, call `equalize-subscription-prices`.
+8. **Submit for review when ready.** For App Store products, call `submit-products-to-store` once each product is ready for submission — this is a confirmed write like the others.


### PR DESCRIPTION
## Summary

Store-state went GA on the hosted MCP server (~Aug 19), so the tools are already live in the toolkit — this PR surfaces the capability and hardens the skill around it.

- **`revenuecat-store-state` skill**
  - New **Prerequisites** section: store credentials (ASC API key / Play service account) + write access, with fail-gracefully guidance
  - New **Confirm before writing** section: show a before → after summary and get explicit user confirmation before production-store writes — live price changes, availability removal, store submission. Reads, screenshot uploads, and Test Store / RC Billing writes are exempt so the gate stays meaningful
  - Recommended flow now covers the GA tools `create-product-prices` and `submit-products-to-store`
- **CHANGELOG**: 2.1.0 entry announcing store-state GA
- **Manifests**: 2.0.1 → 2.1.0 (minor bump — new documented capability)
- **README**: Store Product Management example workflow

Linear: [RICO-428](https://linear.app/revenuecat/issue/RICO-428/ai-toolkit-surface-store-state-now-that-its-ga-skill-hardening)

A companion docs-site PR adds store-state to the AI Toolkit skills table.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Skill guidance now covers production App Store / Play writes (prices, availability, submission). Risk is in agent behavior, not runtime code; confirmation and credential checks mitigate it.
> 
> **Overview**
> Marks **store-state product management as generally available** and bumps the RevenueCat plugin to **2.1.0**.
> 
> The `revenuecat-store-state` skill now documents store-credential prerequisites, requires a before → after summary plus explicit confirmation for live price changes, availability removal, and store submission, and extends the recommended flow with `create-product-prices` and `submit-products-to-store`.
> 
> README adds a store product management example; CHANGELOG and plugin manifests are updated in lockstep.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 209529c33574703abc62a26bc6499becf675b767. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->