### PR TITLE
Add a revenuecat-cli skill and reference it where the CLI applies

### DIFF
--- a/revenuecat/skills/create-revenuecat-project/SKILL.md
+++ b/revenuecat/skills/create-revenuecat-project/SKILL.md
@@ -9,7 +9,7 @@ Guide through setting up a complete RevenueCat project from scratch.
 
 ## Instructions
 
-**Important:** Use the RevenueCat MCP server for all tool calls. The MCP server may have access to multiple projects. Always use `list-projects` first to retrieve all accessible projects. If multiple projects are returned, ask the user which project to use or if they want to create a new one.
+**Important:** Use the RevenueCat MCP server or the `rc` CLI (whichever the user has available) for all operations below; both expose the same actions. Always list projects first (`list-projects` or `rc projects list`) to retrieve all accessible projects. If multiple projects are returned, ask the user which project to use or if they want to create a new one.
 
 ### Phase 1: Discovery
 
@@ -22,7 +22,7 @@ Ask targeted questions to understand the developer's needs:
 
 ### Phase 2: Create Resources
 
-Execute in this order — dependencies matter. 
+Execute in this order — dependencies matter. Each step names the MCP tool; the equivalent `rc` commands are `rc projects create`, `rc apps create`, `rc products create`, `rc entitlements create`, `rc entitlements attach`, `rc offerings create`, `rc packages create`, `rc packages attach`, and `rc apps keys`.
 
 1. Verify/Create Project
 `list-projects` - list accessible projects

--- a/revenuecat/skills/create-revenuecat-project/SKILL.md
+++ b/revenuecat/skills/create-revenuecat-project/SKILL.md
@@ -9,7 +9,7 @@ Guide through setting up a complete RevenueCat project from scratch.
 
 ## Instructions
 
-**Important:** Use the RevenueCat MCP server or the `rc` CLI (whichever the user has available) for all operations below; both expose the same actions. Always list projects first (`list-projects` or `rc projects list`) to retrieve all accessible projects. If multiple projects are returned, ask the user which project to use or if they want to create a new one.
+**Important:** Use the RevenueCat MCP server or the `rc` CLI (whichever the user has available) for all operations below; both expose the same actions. See the `revenuecat-cli` skill for CLI discovery and conventions. Always list projects first (`list-projects` or `rc projects list`) to retrieve all accessible projects. If multiple projects are returned, ask the user which project to use or if they want to create a new one.
 
 ### Phase 1: Discovery
 

--- a/revenuecat/skills/create-revenuecat-project/SKILL.md
+++ b/revenuecat/skills/create-revenuecat-project/SKILL.md
@@ -9,7 +9,7 @@ Guide through setting up a complete RevenueCat project from scratch.
 
 ## Instructions
 
-**Important:** Use the RevenueCat MCP server or the `rc` CLI (whichever the user has available) for all operations below; both expose the same actions. See the `revenuecat-cli` skill for CLI discovery and conventions. Always list projects first (`list-projects` or `rc projects list`) to retrieve all accessible projects. If multiple projects are returned, ask the user which project to use or if they want to create a new one.
+**Important:** Use the RevenueCat MCP server or the `rc` CLI (whichever the user has available) for all operations below; both cover the same actions for these steps. See the `revenuecat-cli` skill for CLI discovery and conventions. Always list projects first (`list-projects` or `rc projects list`) to retrieve all accessible projects. If multiple projects are returned, ask the user which project to use or if they want to create a new one.
 
 ### Phase 1: Discovery
 

--- a/revenuecat/skills/integrate-revenuecat/SKILL.md
+++ b/revenuecat/skills/integrate-revenuecat/SKILL.md
@@ -33,7 +33,7 @@ Before touching the dashboard, gather the facts:
 
 ## 2. Dashboard side
 
-Use whichever surface the user has available: the RevenueCat MCP server or the `rc` CLI (see the `revenuecat-cli` skill for CLI discovery and conventions). Both expose the same operations, and each step below notes the MCP tool and the `rc` command.
+Use whichever surface the user has available: the RevenueCat MCP server or the `rc` CLI (see the `revenuecat-cli` skill for CLI discovery and conventions). Both cover the same operations for these steps, and each step below notes the MCP tool and the `rc` command.
 
 ### 2a. Get or create the project
 - List accessible projects: `list-projects` (MCP) or `rc projects list`. If multiple, ask the user which one matches this app, or offer to create a new one (`create-project` / `rc projects create`).

--- a/revenuecat/skills/integrate-revenuecat/SKILL.md
+++ b/revenuecat/skills/integrate-revenuecat/SKILL.md
@@ -33,7 +33,7 @@ Before touching the dashboard, gather the facts:
 
 ## 2. Dashboard side
 
-Use whichever surface the user has available: the RevenueCat MCP server or the `rc` CLI. Both expose the same operations, and each step below notes the MCP tool and the `rc` command.
+Use whichever surface the user has available: the RevenueCat MCP server or the `rc` CLI (see the `revenuecat-cli` skill for CLI discovery and conventions). Both expose the same operations, and each step below notes the MCP tool and the `rc` command.
 
 ### 2a. Get or create the project
 - List accessible projects: `list-projects` (MCP) or `rc projects list`. If multiple, ask the user which one matches this app, or offer to create a new one (`create-project` / `rc projects create`).

--- a/revenuecat/skills/integrate-revenuecat/SKILL.md
+++ b/revenuecat/skills/integrate-revenuecat/SKILL.md
@@ -1,13 +1,13 @@
 ---
 name: integrate-revenuecat
-description: End-to-end RevenueCat integration — sets up the dashboard side via the RevenueCat MCP (project, app, public API key) and installs/configures the Purchases SDK in the app. Use when the user asks to add RevenueCat, integrate Purchases, install the RevenueCat SDK, set up a RevenueCat API key, configure Purchases on launch, or set up a brand new RevenueCat integration on iOS, Android, Kotlin Multiplatform, Flutter, or React Native.
+description: End-to-end RevenueCat integration — sets up the dashboard side via the RevenueCat MCP or the `rc` CLI (project, app, public API key) and installs/configures the Purchases SDK in the app. Use when the user asks to add RevenueCat, integrate Purchases, install the RevenueCat SDK, set up a RevenueCat API key, configure Purchases on launch, or set up a brand new RevenueCat integration on iOS, Android, Kotlin Multiplatform, Flutter, or React Native.
 ---
 
 # integrate-revenuecat: end-to-end RevenueCat integration
 
 Use this skill when the user wants to add RevenueCat to a project for the first time, or to reconfigure the SDK with a public API key. The skill covers two halves:
 
-1. **Dashboard side** — set up the project, register the app, and obtain the public API key, all through the RevenueCat MCP server.
+1. **Dashboard side** — set up the project, register the app, and obtain the public API key, through the RevenueCat MCP server or the `rc` CLI.
 2. **App side** — install the Purchases SDK, call `Purchases.configure(…)` at app entry, and verify the configuration banner in the logs.
 
 Walk them in order. Most integrations need both halves, even when the user asks "just install the SDK" — the SDK needs an API key from the dashboard.
@@ -21,7 +21,7 @@ Available as `$ARGUMENTS` when invoked as a slash command:
 
 - `platform` (optional): One of `ios`, `android`, `kmp`, `flutter`, `react-native`. If omitted, run the detection algorithm in Section 3a.
 - `app_identifier` (optional): Bundle ID (iOS) or package name (Android). If omitted, read it from the project files (`Info.plist`, `AndroidManifest.xml`, `app.json`, `pubspec.yaml`).
-- `project_name` (optional): Name of the RevenueCat project to use. If omitted, list projects via MCP and ask the user.
+- `project_name` (optional): Name of the RevenueCat project to use. If omitted, list projects (via MCP or `rc projects list`) and ask the user.
 
 ## 1. Understand the status quo
 
@@ -31,25 +31,25 @@ Before touching the dashboard, gather the facts:
 - **Technology**: native iOS (Swift), native Android (Kotlin / Java), React Native, Flutter, Kotlin Multiplatform. SDK list: https://www.revenuecat.com/docs/getting-started/installation.md.
 - **App identifier**: bundle ID (iOS), package name (Android). Pull from `Info.plist` / `AndroidManifest.xml` / `app.json` / `pubspec.yaml` rather than asking.
 
-## 2. Dashboard side — RevenueCat MCP
+## 2. Dashboard side
 
-Use the RevenueCat MCP server for every tool call below.
+Use whichever surface the user has available: the RevenueCat MCP server or the `rc` CLI. Both expose the same operations, and each step below notes the MCP tool and the `rc` command.
 
 ### 2a. Get or create the project
-- `list-projects` — list accessible projects. If multiple, ask the user which one matches this app, or offer to create a new one.
+- List accessible projects: `list-projects` (MCP) or `rc projects list`. If multiple, ask the user which one matches this app, or offer to create a new one (`create-project` / `rc projects create`).
 - If there is no project, hand off to the `create-revenuecat-project` skill, then resume here.
 - Store the `project_id` for the rest of the steps.
 
 ### 2b. Get or create the app
-- Check which apps are already configured in the project. A `test_store` app is always present; `app_store` and `play_store` apps are present only if the user has finished store-side setup.
+- Check which apps are already configured in the project (`list-apps` / `rc apps list`). A `test_store` app is always present; `app_store` and `play_store` apps are present only if the user has finished store-side setup.
 - Ask the user whether their app is already set up in App Store Connect (iOS) or Google Play Console (Android). Reassure them that store-side setup can come later — the `test_store` app is enough to start integrating.
-- If the user confirms store-side setup is done, call `create-app`:
+- If the user confirms store-side setup is done, call `create-app` (or `rc apps create`):
   - **iOS**: `type: "app_store"`, `bundle_id` from Section 1.
   - **Android**: `type: "play_store"`, `package_name` from Section 1.
   - `name` derived from the identifier or asked from the user.
 
 ### 2c. Get the public API key
-- Call `list-public-api-keys` with the relevant app ID:
+- List public keys for the relevant app ID: `list-public-api-keys` (MCP) or `rc apps keys <app-id>`:
   - `app_store` / `play_store` if the store-side app exists.
   - Otherwise the `test_store` app.
 - The returned key is **public** and safe to embed in client app code. iOS keys are prefixed `appl_…`, Android keys `goog_…`, Amazon `amzn_…`.

--- a/revenuecat/skills/revenuecat-charts/SKILL.md
+++ b/revenuecat/skills/revenuecat-charts/SKILL.md
@@ -14,6 +14,8 @@ When querying a RevenueCat chart, follow this workflow:
 2. Use `get-chart-data` with the right options to retrieve the chart data.
 3. Analyze the data, using scripts for any non-trivial arithmetic.
 
+Via the `rc` CLI (see the `revenuecat-cli` skill): `rc charts list` to list charts, `rc charts options <chart>` for the schema, and `rc charts show <chart>` for the data.
+
 In general, to avoid clogging the context, start with defined timeframes and larger resolution, then narrow down.
 
 ## 1. Discover chart options with `get-chart-options-schema`

--- a/revenuecat/skills/revenuecat-cli/SKILL.md
+++ b/revenuecat/skills/revenuecat-cli/SKILL.md
@@ -1,0 +1,42 @@
+---
+name: revenuecat-cli
+description: Drive RevenueCat from the terminal with the `rc` CLI — an alternative to the RevenueCat MCP server for humans, CI, and agents. Covers install, authentication, command discovery, and output conventions. Referenced by the other RevenueCat skills whenever they offer a CLI path.
+---
+
+# revenuecat-cli: driving RevenueCat from the terminal
+
+`rc` is the official RevenueCat command line interface. It exposes the same project, app, product, entitlement, offering, paywall, chart, and store-state operations as the RevenueCat MCP server. Use whichever surface is available; this skill is the reference for the CLI path.
+
+## Install and authenticate
+
+- Run without installing: `npx @revenuecat/cli <command>` (good for CI and agent sandboxes).
+- Or install: `brew install RevenueCat/tap/rc`, or `npm install -g @revenuecat/cli`.
+- Authenticate once with `rc auth login` (browser OAuth), or set `RC_API_KEY`. Non-interactively, pass `--api-key` or set `RC_API_KEY`.
+
+## Discover the surface
+
+The CLI is self-describing. Don't guess a command or flag, ask the binary:
+
+- `rc commands --json` — the full command tree with capabilities.
+- `rc schema <command> --json` — the flags, args, and examples for one command.
+- `rc --help` and `rc <noun> --help` — human-readable help.
+
+## Output conventions
+
+- `--json` — stable, machine-readable output. Data goes to stdout, progress and chatter to stderr.
+- `--no-input` — never prompt, fail instead. Use in scripts, CI, and agents.
+- `--yes` / `-y` — skip confirmation prompts on mutating commands.
+- `--project-id <id>` selects the project (or set a default with `rc projects use`). Pass it explicitly in scripts.
+- Exit codes: `0` success, `1` error, `2` bad usage, `4` auth, `5` not found, `6` rate limited.
+
+## Common operations
+
+Look up exact flags with `rc schema <command> --json`. The common nouns:
+
+- **Projects and apps** — `rc projects list|create|use`, `rc apps list|create|keys`
+- **Catalog** — `rc products …`, `rc entitlements …`, `rc offerings …`, `rc packages …`
+- **Store credentials and state** — `rc setup apple|google`, `rc products store plan|apply|sync`
+- **Data** — `rc charts list|show`, `rc customers …`
+- **Paywalls** — `rc paywalls generate|edit|publish`
+
+Prefer the specific command. Drop to `rc api <METHOD> <path>` only for endpoints not yet in the CLI surface.

--- a/revenuecat/skills/revenuecat-cli/SKILL.md
+++ b/revenuecat/skills/revenuecat-cli/SKILL.md
@@ -1,42 +1,45 @@
 ---
 name: revenuecat-cli
-description: Drive RevenueCat from the terminal with the `rc` CLI — an alternative to the RevenueCat MCP server for humans, CI, and agents. Covers install, authentication, command discovery, and output conventions. Referenced by the other RevenueCat skills whenever they offer a CLI path.
+description: Drive RevenueCat from the terminal with the `rc` CLI, an alternative to the RevenueCat MCP server for humans, CI, and agents. Covers install, authentication, command discovery, and output conventions. Referenced by the other RevenueCat skills whenever they offer a CLI path.
 ---
 
 # revenuecat-cli: driving RevenueCat from the terminal
 
-`rc` is the official RevenueCat command line interface. It exposes the same project, app, product, entitlement, offering, paywall, chart, and store-state operations as the RevenueCat MCP server. Use whichever surface is available; this skill is the reference for the CLI path.
+`rc` is the official RevenueCat command line interface. It covers most of the same project, app, product, entitlement, offering, paywall, chart, and store-state operations as the RevenueCat MCP server (the CLI adds paywall generate/edit; the MCP server has some SDK feature-gate and experiment tools the CLI does not). Use whichever surface is available; this skill is the reference for the CLI path.
 
 ## Install and authenticate
 
 - Run without installing: `npx @revenuecat/cli <command>` (good for CI and agent sandboxes).
 - Or install: `brew install RevenueCat/tap/rc`, or `npm install -g @revenuecat/cli`.
 - Authenticate once with `rc auth login` (browser OAuth), or set `RC_API_KEY`. Non-interactively, pass `--api-key` or set `RC_API_KEY`.
+- The CLI authenticates with a RevenueCat **secret** key (`sk_...`); that is correct because the CLI is a server-side tool. This is not the same as the **public** SDK keys (`appl_`/`goog_`/`amzn_`) you fetch for client app code. Never put a secret key in an app.
 
 ## Discover the surface
 
 The CLI is self-describing. Don't guess a command or flag, ask the binary:
 
-- `rc commands --json` — the full command tree with capabilities.
-- `rc schema <command> --json` — the flags, args, and examples for one command.
-- `rc --help` and `rc <noun> --help` — human-readable help.
+- `rc commands --json` lists the full command tree. Capability IDs appear in colon form (`apps:create`, `products:store:plan`).
+- `rc commands --schemas --json` returns every command's flags, args, and examples in one call. This is the most reliable way for an agent to discover per-command detail.
+- `rc schema <command> --json` returns detail for a single command, but the command must be **space-separated tokens** (`rc schema apps create`), not the colon form from `rc commands`. `rc schema apps:create` silently returns the root schema, so when in doubt use `rc commands --schemas`.
+- `rc --help` and `rc <noun> --help` give human-readable help.
 
 ## Output conventions
 
-- `--json` — stable, machine-readable output. Data goes to stdout, progress and chatter to stderr.
-- `--no-input` — never prompt, fail instead. Use in scripts, CI, and agents.
-- `--yes` / `-y` — skip confirmation prompts on mutating commands.
+- `--json` gives stable, machine-readable output. Data goes to stdout, progress and chatter to stderr.
+- The envelope is `{ "data": ... }`, but the shape under `data` varies by command: lists are usually `data.items[]`, though some commands use other keys (charts use `data.names[]`). Inspect the schema or the response rather than assuming `data.items`.
+- `--no-input` never prompts, it fails instead. Use it in scripts, CI, and agents.
+- `--yes` / `-y` skips confirmation prompts on mutating commands.
 - `--project-id <id>` selects the project (or set a default with `rc projects use`). Pass it explicitly in scripts.
 - Exit codes: `0` success, `1` error, `2` bad usage, `4` auth, `5` not found, `6` rate limited.
 
 ## Common operations
 
-Look up exact flags with `rc schema <command> --json`. The common nouns:
+Look up exact flags with `rc commands --schemas --json` (or `rc schema <space-separated command>`). The common nouns:
 
-- **Projects and apps** — `rc projects list|create|use`, `rc apps list|create|keys`
-- **Catalog** — `rc products …`, `rc entitlements …`, `rc offerings …`, `rc packages …`
-- **Store credentials and state** — `rc setup apple|google`, `rc products store plan|apply|sync`
-- **Data** — `rc charts list|show`, `rc customers …`
-- **Paywalls** — `rc paywalls generate|edit|publish`
+- **Projects and apps**: `rc projects list|create|use`, `rc apps list|create|keys`
+- **Catalog**: `rc products ...`, `rc entitlements ...`, `rc offerings ...`, `rc packages ...`
+- **Store credentials and state**: `rc setup apple|google`, `rc products store plan|apply|sync`
+- **Data**: `rc charts list|show`, `rc customers ...`
+- **Paywalls**: `rc paywalls generate|edit|publish`
 
 Prefer the specific command. Drop to `rc api <METHOD> <path>` only for endpoints not yet in the CLI surface.

--- a/revenuecat/skills/revenuecat-status/SKILL.md
+++ b/revenuecat/skills/revenuecat-status/SKILL.md
@@ -29,7 +29,7 @@ Can be referenced as `$ARGUMENTS` in the skill.
 
 ## Instructions
 
-Use the RevenueCat MCP server for all tool calls.
+Use the RevenueCat MCP server or the `rc` CLI for all tool calls (see the `revenuecat-cli` skill). Each `list-*` tool below has an `rc <noun> list` equivalent (e.g. `list-offerings` → `rc offerings list`).
 
 When the user invokes this skill, perform the following steps:
 

--- a/revenuecat/skills/revenuecat-status/SKILL.md
+++ b/revenuecat/skills/revenuecat-status/SKILL.md
@@ -29,7 +29,7 @@ Can be referenced as `$ARGUMENTS` in the skill.
 
 ## Instructions
 
-Use the RevenueCat MCP server or the `rc` CLI for all tool calls (see the `revenuecat-cli` skill). Each `list-*` tool below has an `rc <noun> list` equivalent (e.g. `list-offerings` → `rc offerings list`).
+Use the RevenueCat MCP server or the `rc` CLI for all tool calls (see the `revenuecat-cli` skill). Each `list-*` tool below has an `rc <noun> list` equivalent (e.g. `list-offerings` → `rc offerings list`; note `list-webhook-integrations` → `rc webhooks list`).
 
 When the user invokes this skill, perform the following steps:
 

--- a/revenuecat/skills/revenuecat-store-state/SKILL.md
+++ b/revenuecat/skills/revenuecat-store-state/SKILL.md
@@ -9,8 +9,8 @@ The RevenueCat MCP store-state tools read and write product state — status, pr
 
 The same operations are available via the `rc` CLI (see the `revenuecat-cli` skill), but the CLI uses an auditable plan/apply model instead of the MCP read-then-poll model:
 
-- `rc products store show <app-id>` reads current state (the CLI equivalent of `get-product-store-state`).
-- `rc products store plan <app-id> --file <csv|json>` computes a reviewable diff and returns a plan ID.
+- `rc products show <product-id> --store-state` reads a product's current live store state (the closest CLI equivalent of `get-product-store-state`).
+- `rc products store plan <app-id> --file <csv|json>` computes a reviewable diff and returns a plan ID; `rc products store show <plan-id>` re-displays a saved plan.
 - `rc products store apply <plan-id>` applies that plan (or `rc products store discard <plan-id>`). Apply handles the async operation internally, so there is no separate poll step.
 - `rc products prices set` sets prices; `rc products store screenshot <product-id>` uploads a review screenshot.
 

--- a/revenuecat/skills/revenuecat-store-state/SKILL.md
+++ b/revenuecat/skills/revenuecat-store-state/SKILL.md
@@ -7,6 +7,8 @@ description: Use when the user wants to inspect or change the state of products 
 
 The RevenueCat MCP store-state tools read and write product state — status, pricing, availability, and review metadata — directly in App Store Connect and Google Play Console. Reads are immediate; writes are asynchronous operations that must be polled for completion.
 
+The same operations are available via the `rc` CLI (see the `revenuecat-cli` skill): `rc products store show|plan|apply|sync` and `rc products prices set`.
+
 Refer to the MCP tool schemas for the exact parameters of each tool.
 
 ## Prerequisites

--- a/revenuecat/skills/revenuecat-store-state/SKILL.md
+++ b/revenuecat/skills/revenuecat-store-state/SKILL.md
@@ -7,7 +7,14 @@ description: Use when the user wants to inspect or change the state of products 
 
 The RevenueCat MCP store-state tools read and write product state — status, pricing, availability, and review metadata — directly in App Store Connect and Google Play Console. Reads are immediate; writes are asynchronous operations that must be polled for completion.
 
-The same operations are available via the `rc` CLI (see the `revenuecat-cli` skill): `rc products store show|plan|apply|sync` and `rc products prices set`.
+The same operations are available via the `rc` CLI (see the `revenuecat-cli` skill), but the CLI uses an auditable plan/apply model instead of the MCP read-then-poll model:
+
+- `rc products store show <app-id>` reads current state (the CLI equivalent of `get-product-store-state`).
+- `rc products store plan <app-id> --file <csv|json>` computes a reviewable diff and returns a plan ID.
+- `rc products store apply <plan-id>` applies that plan (or `rc products store discard <plan-id>`). Apply handles the async operation internally, so there is no separate poll step.
+- `rc products prices set` sets prices; `rc products store screenshot <product-id>` uploads a review screenshot.
+
+Confirm exact flags with `rc commands --schemas --json`.
 
 Refer to the MCP tool schemas for the exact parameters of each tool.
 

--- a/revenuecat/skills/revenuecat-troubleshoot/SKILL.md
+++ b/revenuecat/skills/revenuecat-troubleshoot/SKILL.md
@@ -54,7 +54,7 @@ Use this when steps 3, 4, or 5 above point at dashboard configuration, when the 
 
 ### Phase B: systematic diagnosis
 
-Work through this checklist via MCP tools or their `rc` CLI equivalents (see the `revenuecat-cli` skill). Each `list-*` tool maps to `rc <noun> list` (e.g. `list-offerings` → `rc offerings list`, `list-apps` → `rc apps list`), `list-app-public-api-keys` → `rc apps keys <app-id>`, and `get-product-store-state` → `rc products store show <app-id>`.
+Work through this checklist via MCP tools or their `rc` CLI equivalents (see the `revenuecat-cli` skill). Each `list-*` tool maps to `rc <noun> list` (e.g. `list-offerings` → `rc offerings list`, `list-apps` → `rc apps list`), `list-app-public-api-keys` → `rc apps keys <app-id>`, and `get-product-store-state` → `rc products show <product-id> --store-state`.
 
 #### Check 1: Project overview
 ```

--- a/revenuecat/skills/revenuecat-troubleshoot/SKILL.md
+++ b/revenuecat/skills/revenuecat-troubleshoot/SKILL.md
@@ -10,7 +10,7 @@ Use this skill when the user reports a RevenueCat behavior that does not match e
 This skill combines two angles:
 
 1. **Code-side diagnosis** — turn on debug logging, walk a universal checklist, drop into platform specifics.
-2. **Dashboard inspection** — use the RevenueCat MCP server to read the project, apps, products, entitlements, offerings, and webhooks, and offer fixes.
+2. **Dashboard inspection** — use the RevenueCat MCP server or the `rc` CLI (see the `revenuecat-cli` skill) to read the project, apps, products, entitlements, offerings, and webhooks, and offer fixes.
 
 Work them in order. Most reports resolve before you reach the platform specifics.
 

--- a/revenuecat/skills/revenuecat-troubleshoot/SKILL.md
+++ b/revenuecat/skills/revenuecat-troubleshoot/SKILL.md
@@ -41,7 +41,7 @@ List the apps using the `list-apps` RevenueCat MCP tool. The `bundle_id` (iOS / 
 8. **Verify the appUserID.** If `logIn(appUserID)` was called with an ID that does not match what the user expects, entitlements appear missing because they are attached to a different RC user. Print `Purchases.shared.appUserID` (iOS) / `Purchases.sharedInstance.appUserID` (Android) and confirm it matches.
 9. **Reset and retry.** Uninstall the app, re-sign into the sandbox / tester account, reinstall from the correct channel, relaunch.
 
-## 3. Dashboard inspection via the RevenueCat MCP
+## 3. Dashboard inspection via the RevenueCat MCP or the `rc` CLI
 
 Use this when steps 3, 4, or 5 above point at dashboard configuration, when the user has no working app yet, or when you need to confirm a fix landed.
 
@@ -54,7 +54,7 @@ Use this when steps 3, 4, or 5 above point at dashboard configuration, when the 
 
 ### Phase B: systematic diagnosis
 
-Work through this checklist via MCP tools:
+Work through this checklist via MCP tools or their `rc` CLI equivalents (see the `revenuecat-cli` skill). Each `list-*` tool maps to `rc <noun> list` (e.g. `list-offerings` → `rc offerings list`, `list-apps` → `rc apps list`), `list-app-public-api-keys` → `rc apps keys <app-id>`, and `get-product-store-state` → `rc products store show <app-id>`.
 
 #### Check 1: Project overview
 ```

--- a/revenuecat/skills/revenuecat/SKILL.md
+++ b/revenuecat/skills/revenuecat/SKILL.md
@@ -2,5 +2,5 @@
 name: revenuecat
 description: Used for all interaction with RevenueCat not covered by a different skill
 ---
-Use the RevenueCat MCP server for all interaction with RevenueCat.
+Use the RevenueCat MCP server or the `rc` CLI for all interaction with RevenueCat. See the `revenuecat-cli` skill for the CLI's commands and conventions.
 Refer to the RevenueCat docs under https://www.revenuecat.com/docs. You can find markdown versions of individual pages by appending a `.md` to the URL of a docs page.


### PR DESCRIPTION
The skills assumed the RevenueCat MCP server as the only surface. This adds the `rc` CLI as an equal option and gives the CLI a home.

**New skill: `revenuecat-cli`** — install, auth, command discovery (`rc commands --json`, `rc schema <cmd> --json`), and output conventions (`--json`, `--no-input`, exit codes). This is the one place agents learn how to drive the CLI.

**Referenced from the CLI-capable skills:**
- `create-revenuecat-project`, `integrate-revenuecat` — the `rc` command noted next to each MCP tool
- `revenuecat-status`, `revenuecat-store-state`, `revenuecat-troubleshoot`, `revenuecat-charts`, and the root `revenuecat` skill — offer `rc` alongside MCP

**Left MCP-only:** `revenuecat-sdk-compatibility` (its `list-sdk-feature-gates` / `list-sdk-versions` tools have no CLI equivalent).

8 files, +60/−14. No packaging, manifest, workflow, or SDK-sample changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only updates to agent skill markdown; no runtime, SDK, or API behavior changes.
> 
> **Overview**
> Agent skills no longer assume the **RevenueCat MCP server** is the only way to drive the dashboard. They now treat **MCP or the `rc` CLI** as interchangeable where both support the same operations, and point agents to a new **`revenuecat-cli`** skill for install, auth, discovery (`rc commands --schemas --json`), and scripting flags (`--json`, `--no-input`, exit codes).
> 
> **`create-revenuecat-project`** and **`integrate-revenuecat`** map each MCP step to named `rc` commands (e.g. `list-projects` / `rc projects list`, `rc apps keys`). **`revenuecat-status`**, **`revenuecat-troubleshoot`**, **`revenuecat-charts`**, **`revenuecat-store-state`**, and the root **`revenuecat`** skill document CLI equivalents; store-state notes the CLI’s **plan/apply** flow vs MCP read-and-poll. **`revenuecat-sdk-compatibility`** is unchanged (MCP-only tools).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c43afa93b1441b5e0099401e05a522a90feb53dd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->