### PR TITLE
feat(ai-toolkit): experiment management

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,7 +13,7 @@
       "displayName": "RevenueCat",
       "source": "./revenuecat",
       "description": "Set up RevenueCat, integrate it, and access data.",
-      "version": "2.1.0",
+      "version": "2.2.0",
       "category": "developer-tools",
       "author": { "name": "RevenueCat" },
       "homepage": "https://www.revenuecat.com",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -3,7 +3,7 @@
 	"name": "revenuecat",
 	"displayName": "RevenueCat",
 	"description": "Set up RevenueCat, integrate it, and access data.",
-	"version": "2.1.0",
+	"version": "2.2.0",
 	"license": "MIT",
 	"keywords": ["revenuecat", "in-app-purchases", "subscriptions", "monetization", "iap", "mcp"],
 	"author": {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to the RevenueCat AI Toolkit will be documented in this file
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.2.0] – 2026-08-26
+
+### Added
+
+- **Experiment management is now generally available** — The RevenueCat MCP server's experiment tools (`create-experiment`, `update-experiment`, `start-experiment`, `pause-experiment`, `resume-experiment`, `stop-experiment`) let agents set up and manage A/B tests, alongside the existing read tools (`list-experiments`, `get-experiment`, `get-experiment-results`)
+- **revenuecat-experiments** — New skill for setting up and managing experiments: preparing control and treatment offerings (duplicating offerings, editing or creating treatment paywalls, swapping products for price tests), creating the experiment as a draft, and driving the start/pause/resume/stop lifecycle with explicit user confirmation before starting
+
+---
+
 ## [2.1.0] – 2026-08-21
 
 ### Added
@@ -135,6 +144,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Store-specific setup instructions (App Store Connect, Google Play Console)
 - Configuration validation and issue highlighting
 
+[2.2.0]: https://github.com/RevenueCat/ai-toolkit/compare/v2.1.0...v2.2.0
 [2.1.0]: https://github.com/RevenueCat/ai-toolkit/compare/v2.0.0...v2.1.0
 [2.0.0]: https://github.com/RevenueCat/ai-toolkit/compare/v1.0.0...v2.0.0
 [1.0.0]: https://github.com/RevenueCat/ai-toolkit/releases/tag/v1.0.0

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ai-toolkit",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "description": "RevenueCat plugin marketplace for AI coding assistants",
   "type": "module",
   "scripts": {

--- a/revenuecat/.claude-plugin/plugin.json
+++ b/revenuecat/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
 	"name": "revenuecat",
 	"displayName": "RevenueCat",
 	"description": "Set up RevenueCat, integrate it, and access data.",
-	"version": "2.1.0",
+	"version": "2.2.0",
 	"license": "MIT",
 	"keywords": ["revenuecat", "in-app-purchases", "subscriptions", "monetization", "iap", "mcp"],	
 	"author": {

--- a/revenuecat/.codex-plugin/plugin.json
+++ b/revenuecat/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "revenuecat",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "description": "Configure your RevenueCat integration and access data from your RevenueCat projects.",
   "homepage": "https://www.revenuecat.com/docs/tools/mcp/overview",
   "repository": "https://github.com/RevenueCat/ai-toolkit",

--- a/revenuecat/.cursor-plugin/plugin.json
+++ b/revenuecat/.cursor-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "revenuecat",
   "description": "Configure your RevenueCat integration and access data from your RevenueCat projects.",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "license": "MIT",
   "keywords": ["revenuecat", "in-app-purchases", "subscriptions", "monetization", "iap", "mcp"],
   "author": {

--- a/revenuecat/gemini-extension.json
+++ b/revenuecat/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "revenuecat",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "description": "Configure RevenueCat projects, products, entitlements, and offerings from Gemini CLI.",
   "mcpServers": {
     "revenuecat": {

--- a/revenuecat/plugin.json
+++ b/revenuecat/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
   "name": "revenuecat",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "description": "Set up RevenueCat, integrate it, and access data.",
   "author": {
     "name": "RevenueCat",

--- a/revenuecat/skills/revenuecat-experiments/SKILL.md
+++ b/revenuecat/skills/revenuecat-experiments/SKILL.md
@@ -1,0 +1,39 @@
+---
+name: revenuecat-experiments
+description: Use when the user asks to create, prepare, or set up a RevenueCat experiment (A/B test), to prepare its variant offerings or paywalls, or to start, pause, resume, or stop an experiment via the RevenueCat MCP experiment tools
+---
+
+# Setting up and managing experiments
+
+A RevenueCat experiment compares two to four offerings: `offering_a` (the control) against `offering_b`–`offering_d` (the treatments). Enrolled customers are served their variant's offering instead of the project's current offering. Setting up an experiment means preparing one offering per arm, then creating the experiment as a draft.
+
+Refer to the MCP tool schemas for the exact parameters of each tool; the `create-experiment` schema also lists the available experiment types with their recommended primary and secondary metrics.
+
+## Preparing the arms
+
+Keep the arms identical except for the one aspect under test, otherwise results cannot be attributed to the change. For example, when measuring the impact of a lower subscription price, both arms should share the same paywall design and packages, differing only in the price of the products.
+
+**Control.** When the control arm is "what production does today", pass the current offering (`is_current` in `list-offerings`) directly as `offering_a_id` — do not duplicate it. Duplicate only when control itself needs changes relative to production.
+
+**Treatments.** Start each treatment from a duplicate of the offering closest to it (usually the control offering). `duplicate-offering` copies the packages (attaching the same existing products) and also copies its paywall as a new unpublished draft; it returns the new offering, including its new `paywall_id`. Then apply the one change under test:
+
+- Paywall change (copy, layout, CTA, pricing display, ...): edit the duplicated paywall with `edit-paywall-ai`. Request only the minimum changes required to measure the desired effect, and verify the result by looking at the resulting paywall.
+- Price, trial, or introductory-offer change: these live on store products, so the treatment offering needs different products. Create them and their store counterparts (see the `revenuecat-store-state` skill), then swap them into the duplicated offering's packages: detach the copied products with `detach-products-from-package`, then attach the new ones with `attach-products-to-package`.
+- Brand-new paywall: duplicate the offering with `include_paywall: false`, then call `create-paywall-ai` with the new offering's `offering_id` so the generated draft is attached to it directly. A paywall and an offering pair 1:1 — `attach-offering-to-paywall` fails if either side is already paired; undo a wrong pairing with `detach-offering-from-paywall` (unpublish the paywall first if it is published).
+
+**Publish treatment paywalls.** A duplicated or newly created paywall is an unpublished draft, and a variant only serves the published version. Publish each treatment paywall with `publish-paywall` before the experiment starts. This is the exception to the rule against proactive publishing, and it is safe: the treatment offering is not the current offering, so no customer sees the paywall until the experiment starts enrolling.
+
+## Creating the experiment
+
+Create a draft with `create-experiment`: display name, `enrollment_percentage`, the arm offering IDs, `experiment_type`, a `primary_metric` (plus `secondary_metrics`) matching the hypothesis, `enrollment_mode` (`only_new` unless the user explicitly wants to include existing customers), and any targeting and notes. Creating never starts the experiment. Adjust a draft with `update-experiment`.
+
+Before starting, verify each arm: treatment paywalls are published, packages contain the intended products, and any new products are available on the stores.
+
+## Lifecycle
+
+- `start-experiment` begins enrolling real customers — only run it with the user's explicit confirmation.
+- `pause-experiment` stops enrollment but keeps serving enrolled customers their variant and keeps collecting data.
+- `resume-experiment` continues enrollment.
+- `stop-experiment` is terminal: enrolled customers fall back to the default offering and the experiment can never be restarted.
+
+To interpret results once the experiment is running, use the `revenuecat-experiment-analysis` skill.

--- a/revenuecat/skills/revenuecat-experiments/SKILL.md
+++ b/revenuecat/skills/revenuecat-experiments/SKILL.md
@@ -5,29 +5,29 @@ description: Use when the user asks to create, prepare, or set up a RevenueCat e
 
 # Setting up and managing experiments
 
-A RevenueCat experiment compares two to four offerings: `offering_a` (the control) against `offering_b`–`offering_d` (the treatments). Enrolled customers are served their variant's offering instead of the project's current offering. Setting up an experiment means preparing one offering per arm, then creating the experiment as a draft.
+A RevenueCat experiment compares two to four offerings: `offering_a` (the control) against `offering_b`–`offering_d` (the treatments). Enrolled customers are served their variant's offering instead of the project's current offering. Setting up an experiment means preparing one offering per variant, then creating the experiment as a draft.
 
 Refer to the MCP tool schemas for the exact parameters of each tool; the `create-experiment` schema also lists the available experiment types with their recommended primary and secondary metrics.
 
-## Preparing the arms
+## Preparing the variants
 
-Keep the arms identical except for the one aspect under test, otherwise results cannot be attributed to the change. For example, when measuring the impact of a lower subscription price, both arms should share the same paywall design and packages, differing only in the price of the products.
+Keep the variants identical except for the one aspect under test, otherwise results cannot be attributed to the change. For example, when measuring the impact of a lower subscription price, both variants should share the same paywall design and packages, differing only in the price of the products.
 
-**Control.** When the control arm is "what production does today", pass the current offering (`is_current` in `list-offerings`) directly as `offering_a_id` — do not duplicate it. Duplicate only when control itself needs changes relative to production.
+**Control.** When the control variant is "what production does today", pass the current offering (`is_current` in `list-offerings`) directly as `offering_a_id` — do not duplicate it. Duplicate only when control itself needs changes relative to production.
 
-**Treatments.** Start each treatment from a duplicate of the offering closest to it (usually the control offering). `duplicate-offering` copies the packages (attaching the same existing products) and also copies its paywall as a new unpublished draft; it returns the new offering, including its new `paywall_id`. Then apply the one change under test:
+**Treatments.** First check with `list-offerings` whether an offering already exists that matches what the treatment should serve, and reuse it instead of duplicating. Otherwise, start each treatment from a duplicate of the offering closest to it (usually the control offering). `duplicate-offering` copies the packages (attaching the same existing products) and, if the source offering has a paywall, also copies it as a new unpublished draft; it returns the new offering, including its new `paywall_id`. Then apply the one change under test:
 
-- Paywall change (copy, layout, CTA, pricing display, ...): edit the duplicated paywall with `edit-paywall-ai`. Request only the minimum changes required to measure the desired effect, and verify the result by looking at the resulting paywall.
-- Price, trial, or introductory-offer change: these live on store products, so the treatment offering needs different products. Create them and their store counterparts (see the `revenuecat-store-state` skill), then swap them into the duplicated offering's packages: detach the copied products with `detach-products-from-package`, then attach the new ones with `attach-products-to-package`.
+- Paywall change (copy, layout, CTA, pricing display, ...): this requires the app to use RevenueCat Paywalls — a paywall is an optional property of an offering, and if the control offering has none (`paywall_id` is `null`). Otherwise, edit the duplicated paywall with `edit-paywall-ai`. Request only the minimum changes required to measure the desired effect, and verify the result by looking at the resulting paywall.
+- Price, trial, or introductory-offer change: these live on store products, so the treatment offering needs different products. Check with `list-products` whether suitable products already exist; create only the missing ones and their store counterparts (see the `revenuecat-store-state` skill). Then swap them into the duplicated offering's packages: detach the copied products with `detach-products-from-package`, then attach the new ones with `attach-products-to-package`.
 - Brand-new paywall: duplicate the offering with `include_paywall: false`, then call `create-paywall-ai` with the new offering's `offering_id` so the generated draft is attached to it directly. A paywall and an offering pair 1:1 — `attach-offering-to-paywall` fails if either side is already paired; undo a wrong pairing with `detach-offering-from-paywall` (unpublish the paywall first if it is published).
 
-**Publish treatment paywalls.** A duplicated or newly created paywall is an unpublished draft, and a variant only serves the published version. Publish each treatment paywall with `publish-paywall` before the experiment starts. This is the exception to the rule against proactive publishing, and it is safe: the treatment offering is not the current offering, so no customer sees the paywall until the experiment starts enrolling.
+**Publish treatment paywalls.** A duplicated or newly created paywall is an unpublished draft, and a variant only serves the published version. If new paywalls were created in previous steps, publish each treatment paywall with `publish-paywall` before the experiment starts. This is the exception to the rule against proactive publishing, and it is safe: the treatment offering is not the current offering, so no customer sees the paywall until the experiment starts enrolling.
 
 ## Creating the experiment
 
-Create a draft with `create-experiment`: display name, `enrollment_percentage`, the arm offering IDs, `experiment_type`, a `primary_metric` (plus `secondary_metrics`) matching the hypothesis, `enrollment_mode` (`only_new` unless the user explicitly wants to include existing customers), and any targeting and notes. Creating never starts the experiment. Adjust a draft with `update-experiment`.
+Create a draft with `create-experiment`: display name, `enrollment_percentage`, the variant offering IDs, `experiment_type`, a `primary_metric` (plus `secondary_metrics`) matching the hypothesis, `enrollment_mode` (`only_new` unless the user explicitly wants to include existing customers), and any targeting and notes. Creating never starts the experiment. Adjust a draft with `update-experiment`.
 
-Before starting, verify each arm: treatment paywalls are published, packages contain the intended products, and any new products are available on the stores.
+Before starting, verify each variant: treatment paywalls are published, packages contain the intended products, and any new products are available on the stores.
 
 ## Lifecycle
 


### PR DESCRIPTION
The MCP can now manage experiments. Here, we add a skill to describe common experiment-related workflows.

### Checklist
- [ ] If applicable, unit tests

### Motivation
<!-- Why is this change required? What problem does it solve? -->
<!-- Please link to issues following this format: Resolves #999999 -->

### Description
<!-- Describe your changes in detail -->
<!-- Please describe in detail how you tested your changes -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and version metadata only; no runtime or MCP server code changes in this diff.
> 
> **Overview**
> **Releases 2.2.0** across the marketplace, root and `revenuecat` plugin manifests, and `package.json`, with matching **CHANGELOG** notes for experiment management GA on the MCP server.
> 
> Adds the **`revenuecat-experiments`** skill (`revenuecat/skills/revenuecat-experiments/SKILL.md`) so agents can run end-to-end experiment workflows: preparing control vs treatment offerings (reuse current offering, duplicate offerings, paywall edits via `edit-paywall-ai`, product swaps for price tests with cross-reference to `revenuecat-store-state`), publishing treatment paywalls before start, creating/updating draft experiments via MCP, and lifecycle actions (`start` / `pause` / `resume` / `stop`) with **explicit user confirmation before `start-experiment`**. Results interpretation stays pointed at the existing **`revenuecat-experiment-analysis`** skill.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 54b8f1bd30497363ac65ce4ee9cb7828b0b3b2c5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->