### PR TITLE
skills(store-state): trigger on Web Billing and Test Store too

### DIFF
--- a/revenuecat/skills/revenuecat-store-state/SKILL.md
+++ b/revenuecat/skills/revenuecat-store-state/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: revenuecat-store-state
-description: Use when the user wants to inspect or change the state of products in App Store Connect or Google Play Console (prices, availability, review screenshots) via the RevenueCat MCP store-state tools
+description: Use when the user wants to inspect or change the state of products in App Store Connect, Google Play Console, Web Billing, or the Test Store (prices, availability, review screenshots) via the RevenueCat MCP store-state tools
 ---
 
 # Managing product store state


### PR DESCRIPTION
The store-state skill's description only named App Store Connect and Google Play, so agents asked about Web Billing or Test Store product state would never fire it. Store-state plans cover those stores too (the skill body already mentions them). One-line description tweak.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only skill description change with no runtime or product logic impact.
> 
> **Overview**
> Updates the **`revenuecat-store-state`** skill metadata so agents can select it when users ask about **Web Billing** or **Test Store** product state, not only App Store Connect and Google Play Console.
> 
> The change is a **one-line `description` tweak** in `SKILL.md`; the skill body already covered those stores (e.g. confirmation rules for Test Store / RC Billing). This aligns routing/triggering with the actual store-state tool scope.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a1d259c8fc299d7b629cc6d285573828aa6abe6e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->